### PR TITLE
Bugfix/chromeless default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Assume `PlayerConfiguration.chromeless` to be `true` if not specified.
+
 ## [0.1.1] - 23-06-06
 
 ### Fixed

--- a/src/ui/THEOplayerDefaultUi.tsx
+++ b/src/ui/THEOplayerDefaultUi.tsx
@@ -52,7 +52,7 @@ export interface THEOplayerDefaultUiProps {
 export function THEOplayerDefaultUi(props: THEOplayerDefaultUiProps) {
   const { theme, config, topSlot, bottomSlot, style } = props;
   const [player, setPlayer] = useState<THEOplayer | undefined>(undefined);
-  const chromeless = config?.chromeless ?? false;
+  const chromeless = config?.chromeless ?? true;
 
   const onPlayerReady = (player: THEOplayer) => {
     setPlayer(player);


### PR DESCRIPTION
Before, users had to explicitly indicate `chromeless: true` if they want to use the `THEOplayerDefaultUi` component, otherwise it would assume `chromeless: false` and not render the UI.

```
const playerConfig: PlayerConfiguration = {
  chromeless: true
};
```