### PR TITLE
Bugfix/tappable hidden UI controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue where components were still tappable after the UI had faded out.
+
 ### Changed
 
 - Assume `PlayerConfiguration.chromeless` to be `true` if not specified.

--- a/src/ui/components/uicontroller/UiContainer.tsx
+++ b/src/ui/components/uicontroller/UiContainer.tsx
@@ -308,7 +308,7 @@ export class UiContainer extends PureComponent<React.PropsWithChildren<UiContain
 
   render() {
     const { player, theme, top, center, bottom, children, style, topStyle, centerStyle, bottomStyle, behind } = this.props;
-    const { fadeAnimation, currentMenu, error, firstPlay, pip } = this.state;
+    const { fadeAnimation, currentMenu, error, firstPlay, pip, showing } = this.state;
 
     if (error !== undefined) {
       return <ErrorDisplay error={error} />;
@@ -328,6 +328,7 @@ export class UiContainer extends PureComponent<React.PropsWithChildren<UiContain
         <Animated.View
           style={[combinedContainerStyle, { opacity: fadeAnimation }]}
           onTouchStart={this.onUserAction_}
+          pointerEvents={showing ? 'auto' : 'box-only'}
           {...(Platform.OS === 'web' ? { onMouseMove: this.onUserAction_, onMouseLeave: this.doFadeOut_ } : {})}>
           <>
             {/* The UI background */}


### PR DESCRIPTION
UI components were still tappable after the UI had faded out.
It is expected that a user has to first tap the UI (or move the mouse) to make the UI visible, after which the components become interactive again.
`pointerEvents="auto"` is the default, making the container and its children accept pointer events.
`pointerEvents="box-only"`, while hidden, makes only the UI container interactive, children do not receive pointer events. 