### PR TITLE
Bugfix/skip buttons downloaded mp4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed an issue where the skip buttons would remain disabled for MP4 sources.
+
 ## [0.5.0] - 24-03-06
 
 ### Added

--- a/src/ui/components/button/SkipButton.tsx
+++ b/src/ui/components/button/SkipButton.tsx
@@ -58,7 +58,7 @@ export class SkipButton extends PureComponent<SkipButtonProps, SkipButtonState> 
   }
 
   private readonly onProgress = (event: ProgressEvent) => {
-    this.setState({ enabled: event.seekable.length > 0 });
+    this.setState({ enabled: event.seekable.length > 0 || event.buffered.length > 0 });
   };
 
   private readonly onPress = () => {

--- a/src/ui/components/button/SkipButton.tsx
+++ b/src/ui/components/button/SkipButton.tsx
@@ -49,16 +49,23 @@ export class SkipButton extends PureComponent<SkipButtonProps, SkipButtonState> 
   componentDidMount() {
     const player = (this.context as UiContext).player;
     player.addEventListener(PlayerEventType.PROGRESS, this.onProgress);
+    player.addEventListener(PlayerEventType.PLAYING, this.onPlaying);
     this.setState({ enabled: player.seekable.length > 0 });
   }
 
   componentWillUnmount() {
     const player = (this.context as UiContext).player;
     player.removeEventListener(PlayerEventType.PROGRESS, this.onProgress);
+    player.removeEventListener(PlayerEventType.PLAYING, this.onPlaying);
   }
 
   private readonly onProgress = (event: ProgressEvent) => {
     this.setState({ enabled: event.seekable.length > 0 || event.buffered.length > 0 });
+  };
+
+  private readonly onPlaying = () => {
+    const player = (this.context as UiContext).player;
+    this.setState({ enabled: player.seekable.length > 0 || player.buffered.length > 0 });
   };
 
   private readonly onPress = () => {

--- a/src/ui/components/button/SkipButton.tsx
+++ b/src/ui/components/button/SkipButton.tsx
@@ -48,16 +48,16 @@ export class SkipButton extends PureComponent<SkipButtonProps, SkipButtonState> 
 
   componentDidMount() {
     const player = (this.context as UiContext).player;
-    player.addEventListener(PlayerEventType.PROGRESS, this.onTimeupdate);
+    player.addEventListener(PlayerEventType.PROGRESS, this.onProgress);
     this.setState({ enabled: player.seekable.length > 0 });
   }
 
   componentWillUnmount() {
     const player = (this.context as UiContext).player;
-    player.removeEventListener(PlayerEventType.PROGRESS, this.onTimeupdate);
+    player.removeEventListener(PlayerEventType.PROGRESS, this.onProgress);
   }
 
-  private readonly onTimeupdate = (event: ProgressEvent) => {
+  private readonly onProgress = (event: ProgressEvent) => {
     this.setState({ enabled: event.seekable.length > 0 });
   };
 


### PR DESCRIPTION
A `SkipButton`'s `enabled` state is initially set to false and it only changes to true on `PROGRESS` events where the `seekable` ranges are not empty.

This PR adds some changes to make sure SkipButtons are shown for (offline) MP4 assets too. It does this by:

- Also enabling the button if the `buffered` ranges are not empty. On iOS you would only get a `PROGRESS` event at the beginning of the video, when the `seekable` ranges are empty.
- Also enabling/disabling the button on `PLAYING` events, since on Android no `PROGRESS` events are fired in this scenario.
