### PR TITLE
Support THEOplayer version 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- Added support for THEOplayer 7.0 and React Native THEOplayer 7.0.
+
 ### Fixed
 
 - Fixed TypeScript type definitions to export interfaces describing the props for all components.

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -14,7 +14,7 @@
         "react-native": "0.72.7",
         "react-native-google-cast": "^4.6.2",
         "react-native-svg": "^14.0.0",
-        "react-native-theoplayer": "^3.8.0",
+        "react-native-theoplayer": "^7.0.0",
         "react-native-web": "^0.19.9",
         "react-native-web-image-loader": "^0.1.1"
       },
@@ -40,7 +40,7 @@
         "node-polyfill-webpack-plugin": "^2.0.1",
         "prettier": "^2.4.1",
         "react-test-renderer": "18.2.0",
-        "theoplayer": "^6.9.0",
+        "theoplayer": "^7.1.0",
         "typescript": "4.8.4",
         "webpack": "^5.89.0",
         "webpack-cli": "^5.1.4",
@@ -14516,16 +14516,19 @@
       }
     },
     "node_modules/react-native-theoplayer": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/react-native-theoplayer/-/react-native-theoplayer-3.8.0.tgz",
-      "integrity": "sha512-/1ojzfuiu+Ul72oRbUIK37AKTa7npE24/HDq23pqExL0ByBfHCVT70jD2xSJ+oaw+fpYheloPzAq/TZGaMIvRg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-theoplayer/-/react-native-theoplayer-7.0.0.tgz",
+      "integrity": "sha512-E+1JJhfTQaU4DP60Le3uz8p3x/nW2PhBsAZaKDMuSGPVaBl6K/tXBLjbH7YyPJdAuP5ZsMpRewsMDpD77U7JRA==",
       "dependencies": {
         "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "peerDependencies": {
         "react": "*",
         "react-native": "*",
-        "theoplayer": ">=5.0.1"
+        "theoplayer": "^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
         "theoplayer": {
@@ -16093,9 +16096,9 @@
       "dev": true
     },
     "node_modules/theoplayer": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-6.9.0.tgz",
-      "integrity": "sha512-6yS7zcTVw1n2p4AaVt+KKKubvl3L3hzVUgFxKXDuVTfInuqJId2++9sIWcWE8KX1n331D9JZw7mdeejrheMbYw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-7.1.0.tgz",
+      "integrity": "sha512-Ve26DSUTKiZqiESA5+gtwN525dr1UDq7yvEPZVXr5byk906/gr99kQSZsfhV5e0KtPcyUP/62lmCVLCfZK2Xyw==",
       "devOptional": true
     },
     "node_modules/throat": {

--- a/example/package.json
+++ b/example/package.json
@@ -17,7 +17,7 @@
     "react-native": "0.72.7",
     "react-native-google-cast": "^4.6.2",
     "react-native-svg": "^14.0.0",
-    "react-native-theoplayer": "^3.8.0",
+    "react-native-theoplayer": "^7.0.0",
     "react-native-web": "^0.19.9",
     "react-native-web-image-loader": "^0.1.1"
   },
@@ -43,7 +43,7 @@
     "node-polyfill-webpack-plugin": "^2.0.1",
     "prettier": "^2.4.1",
     "react-test-renderer": "18.2.0",
-    "theoplayer": "^6.9.0",
+    "theoplayer": "^7.1.0",
     "typescript": "4.8.4",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,9 @@
         "react-native-builder-bob": "^0.18.0",
         "react-native-google-cast": "^4.6.2",
         "react-native-svg": "^13.8.0",
-        "react-native-theoplayer": "^3.8.0",
+        "react-native-theoplayer": "^7.0.0",
         "release-it": "^16.2.0",
-        "theoplayer": "^6.9.0",
+        "theoplayer": "^7.1.0",
         "typedoc": "^0.25.12",
         "typedoc-plugin-external-resolver": "^1.0.3",
         "typedoc-plugin-mdn-links": "^3.1.19",
@@ -48,8 +48,8 @@
         "react-native": "*",
         "react-native-google-cast": "^4.6.2",
         "react-native-svg": "^13.8.0",
-        "react-native-theoplayer": "^2.7.0 || ^3",
-        "theoplayer": "^5.0.1 || ^6"
+        "react-native-theoplayer": "^2.7.0 || ^3 || ^7",
+        "theoplayer": "^5.0.1 || ^6 || ^7"
       },
       "peerDependenciesMeta": {
         "theoplayer": {
@@ -14736,17 +14736,20 @@
       }
     },
     "node_modules/react-native-theoplayer": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/react-native-theoplayer/-/react-native-theoplayer-3.8.0.tgz",
-      "integrity": "sha512-/1ojzfuiu+Ul72oRbUIK37AKTa7npE24/HDq23pqExL0ByBfHCVT70jD2xSJ+oaw+fpYheloPzAq/TZGaMIvRg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-theoplayer/-/react-native-theoplayer-7.0.0.tgz",
+      "integrity": "sha512-E+1JJhfTQaU4DP60Le3uz8p3x/nW2PhBsAZaKDMuSGPVaBl6K/tXBLjbH7YyPJdAuP5ZsMpRewsMDpD77U7JRA==",
       "dev": true,
       "dependencies": {
         "buffer": "^6.0.3"
       },
+      "engines": {
+        "node": ">=18"
+      },
       "peerDependencies": {
         "react": "*",
         "react-native": "*",
-        "theoplayer": ">=5.0.1"
+        "theoplayer": "^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
         "theoplayer": {
@@ -17174,9 +17177,9 @@
       "dev": true
     },
     "node_modules/theoplayer": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-6.9.0.tgz",
-      "integrity": "sha512-6yS7zcTVw1n2p4AaVt+KKKubvl3L3hzVUgFxKXDuVTfInuqJId2++9sIWcWE8KX1n331D9JZw7mdeejrheMbYw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-7.1.0.tgz",
+      "integrity": "sha512-Ve26DSUTKiZqiESA5+gtwN525dr1UDq7yvEPZVXr5byk906/gr99kQSZsfhV5e0KtPcyUP/62lmCVLCfZK2Xyw==",
       "dev": true
     },
     "node_modules/throat": {

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
     "react-native-builder-bob": "^0.18.0",
     "react-native-google-cast": "^4.6.2",
     "react-native-svg": "^13.8.0",
-    "react-native-theoplayer": "^3.8.0",
+    "react-native-theoplayer": "^7.0.0",
     "release-it": "^16.2.0",
-    "theoplayer": "^6.9.0",
+    "theoplayer": "^7.1.0",
     "typedoc": "^0.25.12",
     "typedoc-plugin-external-resolver": "^1.0.3",
     "typedoc-plugin-mdn-links": "^3.1.19",
@@ -72,8 +72,8 @@
     "react-native": "*",
     "react-native-google-cast": "^4.6.2",
     "react-native-svg": "^13.8.0",
-    "react-native-theoplayer": "^2.7.0 || ^3",
-    "theoplayer": "^5.0.1 || ^6"
+    "react-native-theoplayer": "^2.7.0 || ^3 || ^7",
+    "theoplayer": "^5.0.1 || ^6 || ^7"
   },
   "peerDependenciesMeta": {
     "theoplayer": {


### PR DESCRIPTION
We're not affected by any of the breaking changes, so we just need to update the version range of our peer dependencies. 🙂