### PR TITLE
Bugfix/mute button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed an issue where the mute button sometimes did not update its icon after toggling.
+
 ## 0.7.0 (2024-04-11)
 
 ### Added

--- a/src/ui/components/button/MuteButton.tsx
+++ b/src/ui/components/button/MuteButton.tsx
@@ -45,6 +45,7 @@ export class MuteButton extends PureComponent<MuteButtonProps, MuteButtonState> 
   private toggleMuted = () => {
     const player = (this.context as UiContext).player;
     player.muted = !player.muted;
+    this.setState({ muted: player.muted });
   };
 
   render() {


### PR DESCRIPTION
The actual issue is in our iOS SDK where the first volumechangeevents after a preroll ad aren't dispatched. This is a workaround for the issue.