### PR TITLE
Bugfix/seekable not updated for mp4 sourcechange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed an issue where the `SeekBar`'s seekable state was not updated when switching to a MP4 source.
+
 ## 0.7.1 (2024-04-16)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed an issue where the `SeekBar`'s seekable state was not updated when switching to a MP4 source.
+- Fixed an issue where the `SkipButton` components are not rendered when switching sources while casting.
 
 ## 0.7.1 (2024-04-16)
 

--- a/src/ui/components/button/SkipButton.tsx
+++ b/src/ui/components/button/SkipButton.tsx
@@ -65,7 +65,8 @@ export class SkipButton extends PureComponent<SkipButtonProps, SkipButtonState> 
 
   private readonly onPlaying = () => {
     const player = (this.context as UiContext).player;
-    this.setState({ enabled: player.seekable.length > 0 || player.buffered.length > 0 });
+    const isCasting =  player.cast.chromecast?.casting ?? false
+    this.setState({ enabled: player.seekable.length > 0 || player.buffered.length > 0 || isCasting});
   };
 
   private readonly onPress = () => {

--- a/src/ui/components/seekbar/SeekBar.tsx
+++ b/src/ui/components/seekbar/SeekBar.tsx
@@ -74,7 +74,10 @@ export class SeekBar extends PureComponent<SeekBarProps, SeekBarState> {
     }
   };
   private _onLoadedMetadata = (event: LoadedMetadataEvent) => this.setState({ duration: event.duration });
-  private _onDurationChange = (event: DurationChangeEvent) => this.setState({ duration: event.duration });
+  private _onDurationChange = (event: DurationChangeEvent) => {
+    const player = (this.context as UiContext).player;
+    this.setState({ duration: event.duration, seekable: player.seekable });
+  }
   private _onProgress = (event: ProgressEvent) => this.setState({ seekable: event.seekable });
 
   private _onSlidingStart = (value: number) => {


### PR DESCRIPTION
This PR fixes two issues

1. An issue where due to the lack of progress events firing (as expected) for MP4 assets, the seekable state is not updated if you switch to an MP4 source on the same player instance. This messes up the SeekBar, since the thumb is rendered at a percentage into the timeline that is calculated using `seekable.end`. Without this fix, the SeekBar will still use the `seekable.end` of the previous source.
2. An issue where the `SkipButton` components are not rendered on the Sender when switching sources during a Chromecast session, due to the fact that buffered and seekable are not populated yet if the source change happened on the receiver.