### PR TITLE
Bugfix/playbutton ended state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed an issue where on iOS the playButton was displayed as a replay button at the beginning of the stream
+
 ## 0.7.2 (2024-05-15)
 
 ### Fixed

--- a/src/ui/components/button/PlayButton.tsx
+++ b/src/ui/components/button/PlayButton.tsx
@@ -46,7 +46,7 @@ export class PlayButton extends PureComponent<PlayButtonProps, PlayButtonState> 
     context.player.addEventListener(PlayerEventType.SEEKING, this.onSeeking);
     this.setState({
       paused: context.player.paused,
-      ended: context.player.currentTime === context.player.duration,
+      ended: (context.player.duration > 0) && (context.player.currentTime === context.player.duration),
     });
   }
 


### PR DESCRIPTION
At the very beginning of the stream, on iOS, the currentTime is 0 and without preloading so is the duration. In that case currentTime == duration which makes the playButton assume an ended state upon initialisation.