### PR TITLE
Feature/replace slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Replaced slider component as a dependency of the seek bar.
+
+### Fixed
+
+- Fixed an issue where an app using the UI would crash when using the `SeekBar` component while streaming a live asset.
+
 ## 0.9.0 (2024-10-25)
 
 ### Changed

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -39,8 +39,7 @@ The UI components also have a few non-transitive dependencies that are required 
 npm install \
   @theoplayer/react-native-ui \
   react-native-theoplayer \
-  react-native-svg \
-  @react-native-community/slider
+  react-native-svg
 ```
 
 The package contains a number of transitive dependencies that contain native iOS and Android platform code
@@ -54,7 +53,6 @@ module.exports = {
   dependencies: {
     'react-native-google-cast': {},
     'react-native-svg': {},
-    '@react-native-community/slider': {},
   },
 };
 ```

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -60,9 +60,20 @@ export default function App() {
     player.addEventListener(PlayerEventType.SEEKED, console.log);
     player.addEventListener(PlayerEventType.ENDED, console.log);
     player.source = {
-      sources: {
-        src: 'https://cdn.theoplayer.com/video/adultswim/clip.m3u8',
-        type: 'application/x-mpegurl',
+      sources: [
+        {
+          src: 'https://cdn.theoplayer.com/video/dash/bbb_30fps/bbb_with_multiple_tiled_thumbnails.mpd',
+          type: 'application/dash+xml',
+        },
+      ],
+      poster: 'https://cdn.theoplayer.com/video/big_buck_bunny/poster.jpg',
+      metadata: {
+        title: 'Big Buck Bunny',
+        subtitle: 'DASH - Thumbnails in manifest',
+        album: 'React-Native THEOplayer demos',
+        mediaUri: 'https://theoplayer.com',
+        displayIconUri: 'https://cdn.theoplayer.com/video/big_buck_bunny/poster.jpg',
+        artist: 'THEOplayer',
       },
     };
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -15,7 +15,7 @@
         "react-native-google-cast": "^4.8.3",
         "react-native-svg": "^15.8.0",
         "react-native-svg-web": "^1.0.9",
-        "react-native-theoplayer": "^8.10.0",
+        "react-native-theoplayer": "^8.13.0",
         "react-native-web": "^0.19.13",
         "react-native-web-image-loader": "^0.1.1"
       },
@@ -11517,9 +11517,9 @@
       }
     },
     "node_modules/react-native-theoplayer": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/react-native-theoplayer/-/react-native-theoplayer-8.10.0.tgz",
-      "integrity": "sha512-GCMm9vEA2E0GX8avaftCwf8k7haA7PEhY9r1Ogv7VshLJvaZDLLBxTCKKD4vG+Y/UmZyHj1gRu/rnUpeUVbvsw==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/react-native-theoplayer/-/react-native-theoplayer-8.13.0.tgz",
+      "integrity": "sha512-G+YX5Kqd2z17Td3HusVxFVqIDTY6XvO5kj+kQ4yewJZ/anvB27uaJwSKYRB9Cg/HMWOA5Gs2JWy46kw62mCkWQ==",
       "dependencies": {
         "buffer": "^6.0.3"
       },

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -8,7 +8,6 @@
       "name": "example",
       "version": "0.0.1",
       "dependencies": {
-        "@react-native-community/slider": "^4.5.4",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-native": "^0.75.4",
@@ -3146,11 +3145,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@react-native-community/slider": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.4.tgz",
-      "integrity": "sha512-TFhwnrp0LTFG90yat8mqEOBLLMJylpnchO5F0KusH8dI0VzViIVIXOzhnx0mUVqLvRwRPbqBB0tvhxd739UhmA=="
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.75.4",

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -15,7 +15,7 @@
         "react-native-google-cast": "^4.8.3",
         "react-native-svg": "^15.8.0",
         "react-native-svg-web": "^1.0.9",
-        "react-native-theoplayer": "^8.6.0",
+        "react-native-theoplayer": "^8.10.0",
         "react-native-web": "^0.19.13",
         "react-native-web-image-loader": "^0.1.1"
       },
@@ -35,7 +35,7 @@
         "copy-webpack-plugin": "^12.0.2",
         "eslint": "^8.57.1",
         "html-webpack-plugin": "^5.6.3",
-        "theoplayer": "^8.3.0",
+        "theoplayer": "^8.6.2",
         "typescript": "5.0.4",
         "webpack": "^5.95.0",
         "webpack-cli": "^5.1.4",
@@ -11517,9 +11517,9 @@
       }
     },
     "node_modules/react-native-theoplayer": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/react-native-theoplayer/-/react-native-theoplayer-8.6.0.tgz",
-      "integrity": "sha512-LfRlFWVlwd8MIEkOL2+yHqsnFQa5EvpiVXhqTYX5HG2ObfTwX9nQdLhdLlWsLz0xYOsF8wAG8p6nYArzz/Y67w==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/react-native-theoplayer/-/react-native-theoplayer-8.10.0.tgz",
+      "integrity": "sha512-GCMm9vEA2E0GX8avaftCwf8k7haA7PEhY9r1Ogv7VshLJvaZDLLBxTCKKD4vG+Y/UmZyHj1gRu/rnUpeUVbvsw==",
       "dependencies": {
         "buffer": "^6.0.3"
       },
@@ -13037,9 +13037,9 @@
       "dev": true
     },
     "node_modules/theoplayer": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-8.3.0.tgz",
-      "integrity": "sha512-KV9cpPQHVv8cvtt88lRCM+u+gXd64PlDmDq7Yqzcgkoy7RXisHqtiTdxnCO7U2zkMLNy4rM8WVnjWKZNrDbC0g==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-8.6.2.tgz",
+      "integrity": "sha512-+uWxIIeb/JoTiymRaDkE7l+i7Gn7uKaLEoqnFAT2BNvyf+6ByhEy4nQQhggDeh9OGvxwHcBkANqyARkRmlD96g==",
       "devOptional": true
     },
     "node_modules/thingies": {

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@react-native-community/slider": "^4.5.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "^0.75.4",

--- a/example/package.json
+++ b/example/package.json
@@ -18,7 +18,7 @@
     "react-native-google-cast": "^4.8.3",
     "react-native-svg": "^15.8.0",
     "react-native-svg-web": "^1.0.9",
-    "react-native-theoplayer": "^8.6.0",
+    "react-native-theoplayer": "^8.10.0",
     "react-native-web": "^0.19.13",
     "react-native-web-image-loader": "^0.1.1"
   },
@@ -38,7 +38,7 @@
     "copy-webpack-plugin": "^12.0.2",
     "eslint": "^8.57.1",
     "html-webpack-plugin": "^5.6.3",
-    "theoplayer": "^8.3.0",
+    "theoplayer": "^8.6.2",
     "typescript": "5.0.4",
     "webpack": "^5.95.0",
     "webpack-cli": "^5.1.4",

--- a/example/package.json
+++ b/example/package.json
@@ -18,7 +18,7 @@
     "react-native-google-cast": "^4.8.3",
     "react-native-svg": "^15.8.0",
     "react-native-svg-web": "^1.0.9",
-    "react-native-theoplayer": "^8.10.0",
+    "react-native-theoplayer": "^8.13.0",
     "react-native-web": "^0.19.13",
     "react-native-web-image-loader": "^0.1.1"
   },

--- a/example/package.json
+++ b/example/package.json
@@ -6,6 +6,7 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "web": "webpack-dev-server --config ./web/webpack.config.js --mode development",
+    "web-release": "webpack --config ./web/webpack.config.js --mode production",
     "lint": "eslint \"**/*.{ts,tsx}\"",
     "start": "react-native start",
     "test": "jest"

--- a/example/web/webpack.config.js
+++ b/example/web/webpack.config.js
@@ -2,15 +2,16 @@
 const path = require('path');
 const HTMLWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 
-const projectDirectory = path.resolve(__dirname, '..');
+const projectDirectory = path.resolve(__dirname, '../..');
+
+const appDirectory = path.resolve(__dirname, '..');
 
 // A folder for any stub components we need in case there is no counterpart for it on react-native-web.
-const stubDirectory = path.resolve(projectDirectory, './web/stub/');
+const stubDirectory = path.resolve(appDirectory, './web/stub/');
 
 const HTMLWebpackPluginConfig = new HTMLWebpackPlugin({
-  template: path.resolve(projectDirectory, './web/public/index.html'),
+  template: path.resolve(appDirectory, './web/public/index.html'),
   filename: 'index.html',
   inject: 'body',
 });
@@ -26,12 +27,18 @@ const CopyWebpackPluginConfig = new CopyWebpackPlugin({
     {
       // Copy transmuxer worker files.
       // THEOplayer will find them by setting `libraryLocation` in the playerConfiguration.
-      from: path.resolve(projectDirectory, './node_modules/theoplayer/THEOplayer.transmux.*').replace(/\\/g, '/'),
+      from: path.resolve(appDirectory, './node_modules/theoplayer/THEOplayer.transmux.*').replace(/\\/g, '/'),
+      to: `${libraryLocation}/[name][ext]`,
+    },
+    {
+      // Copy service worker
+      // THEOplayer will find them by setting `libraryLocation` in the playerConfiguration.
+      from: path.resolve(appDirectory, './node_modules/theoplayer/theoplayer.sw.js').replace(/\\/g, '/'),
       to: `${libraryLocation}/[name][ext]`,
     },
     {
       // Copy CSS files
-      from: path.resolve(projectDirectory, './web/public/*.css').replace(/\\/g, '/'),
+      from: path.resolve(appDirectory, './web/public/*.css').replace(/\\/g, '/'),
       to: `[name][ext]`,
     },
   ],
@@ -42,15 +49,18 @@ const CopyWebpackPluginConfig = new CopyWebpackPlugin({
 // published. If you depend on uncompiled packages they may cause webpack build
 // errors. To fix this webpack can be configured to compile to the necessary
 // `node_module`.
+//
+// /\.tsx?$/                : process all tsx files.
+// /.*@theoplayer\/.*\.js$/ : process all js files from @theoplayer packages to apply the root import alias. This is only needed for this example.
 const babelLoaderConfiguration = {
-  test: /\.tsx?$/,
+  test: [/\.tsx?$/, /.*@theoplayer\/.*\.js$/],
   exclude: ['/**/*.d.ts', '/**/node_modules/'],
   use: {
     loader: 'babel-loader',
     options: {
       cacheDirectory: true,
       // The 'metro-react-native-babel-preset' preset is recommended to match React Native's packager
-      presets: ['module:metro-react-native-babel-preset'],
+      presets: ['module:@react-native/babel-preset'],
       // Re-write paths to import only the modules needed by the app
       plugins: ['react-native-web'],
     },
@@ -68,15 +78,15 @@ const imageLoaderConfiguration = {
 module.exports = {
   entry: [
     // load any web API polyfills
-    // path.resolve(projectDirectory, 'polyfills-web.js'),
+    // path.resolve(appDirectory, 'polyfills-web.js'),
     // your web-specific entry file
-    path.resolve(projectDirectory, 'index.web.tsx'),
+    path.resolve(appDirectory, 'index.web.tsx'),
   ],
 
   // configures where the build ends up
   output: {
     filename: 'bundle.web.js',
-    path: path.resolve(projectDirectory, outputLocation),
+    path: path.resolve(appDirectory, outputLocation),
   },
 
   module: {
@@ -88,22 +98,23 @@ module.exports = {
       'react-native$': 'react-native-web',
       'react-native-url-polyfill': 'url-polyfill',
       'react-native-google-cast': path.resolve(stubDirectory, 'CastButtonStub'),
-      'react-native-web': path.resolve(projectDirectory, 'node_modules/react-native-web'),
-      'react-native-svg': path.resolve(projectDirectory, 'node_modules/react-native-svg-web'),
+      'react-native-web': path.resolve(appDirectory, 'node_modules/react-native-web'),
+      'react-native-svg': path.resolve(appDirectory, 'node_modules/react-native-svg-web'),
+      theoplayer: path.resolve(appDirectory, 'node_modules/theoplayer'),
 
       // Avoid duplicate react env.
-      react: path.resolve(projectDirectory, 'node_modules/react'),
-      'react-dom': path.resolve(projectDirectory, 'node_modules/react-dom'),
+      react: path.resolve(appDirectory, 'node_modules/react'),
+      'react-dom': path.resolve(appDirectory, 'node_modules/react-dom'),
     },
   },
-  plugins: [HTMLWebpackPluginConfig, CopyWebpackPluginConfig, new NodePolyfillPlugin()],
+  plugins: [HTMLWebpackPluginConfig, CopyWebpackPluginConfig],
   devServer: {
     // Tells dev-server to open the browser after server had been started.
     open: true,
     historyApiFallback: true,
     static: [
       {
-        directory: path.join(projectDirectory, 'web/public'),
+        directory: path.join(appDirectory, 'web/public'),
       },
     ],
     // Hot reload on source changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.9.0",
       "license": "SEE LICENSE AT https://www.theoplayer.com/terms",
       "dependencies": {
+        "@miblanchard/react-native-slider": "^2.6.0",
         "react-native-url-polyfill": "^1.3.0",
         "url-polyfill": "^1.1.12"
       },
@@ -2184,6 +2185,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@miblanchard/react-native-slider": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miblanchard/react-native-slider/-/react-native-slider-2.6.0.tgz",
+      "integrity": "sha512-o7hk/f/8vkqh6QNR5L52m+ws846fQeD/qNCC9CCSRdBqjq66KiCgbxzlhRzKM/gbtxcvMYMIEEJ1yes5cr6I3A==",
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-native": ">=0.59"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.13.0",
-        "@react-native-community/slider": "^4.5.4",
         "@react-native/eslint-config": "^0.75.4",
         "@types/react": "^18.3.12",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -3496,7 +3495,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.4.tgz",
       "integrity": "sha512-TFhwnrp0LTFG90yat8mqEOBLLMJylpnchO5F0KusH8dI0VzViIVIXOzhnx0mUVqLvRwRPbqBB0tvhxd739UhmA==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.75.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "typescript-eslint": "^8.11.0"
       },
       "peerDependencies": {
-        "@react-native-community/slider": "*",
         "react": "*",
         "react-native": "*",
         "react-native-google-cast": "*",
@@ -3490,12 +3489,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@react-native-community/slider": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.4.tgz",
-      "integrity": "sha512-TFhwnrp0LTFG90yat8mqEOBLLMJylpnchO5F0KusH8dI0VzViIVIXOzhnx0mUVqLvRwRPbqBB0tvhxd739UhmA==",
-      "peer": true
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.75.4",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",
-    "@react-native-community/slider": "^4.5.4",
     "@react-native/eslint-config": "^0.75.4",
     "@types/react": "^18.3.12",
     "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     ]
   },
   "dependencies": {
+    "@miblanchard/react-native-slider": "^2.6.0",
     "react-native-url-polyfill": "^1.3.0",
     "url-polyfill": "^1.1.12"
   }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "typescript-eslint": "^8.11.0"
   },
   "peerDependencies": {
-    "@react-native-community/slider": "*",
     "react": "*",
     "react-native": "*",
     "react-native-google-cast": "*",

--- a/src/ui/components/button/PlayButton.tsx
+++ b/src/ui/components/button/PlayButton.tsx
@@ -61,18 +61,10 @@ export class PlayButton extends PureComponent<PlayButtonProps, PlayButtonState> 
   }
 
   private onPlay = () => {
-    const player = (this.context as UiContext).player;
-    if (player.seeking) {
-      return;
-    }
     this.setState({ paused: false, ended: false });
   };
 
   private onPause = () => {
-    const player = (this.context as UiContext).player;
-    if (player.seeking) {
-      return;
-    }
     this.setState({ paused: true });
   };
 

--- a/src/ui/components/hooks/useCurrentTime.ts
+++ b/src/ui/components/hooks/useCurrentTime.ts
@@ -1,0 +1,27 @@
+import { useCallback, useContext, useSyncExternalStore } from 'react';
+import { PlayerContext } from '@theoplayer/react-native-ui';
+import { type PlayerEventMap, PlayerEventType } from 'react-native-theoplayer';
+
+const TIME_CHANGE_EVENTS = [PlayerEventType.TIME_UPDATE, PlayerEventType.SEEKING, PlayerEventType.SEEKED] satisfies ReadonlyArray<
+  keyof PlayerEventMap
+>;
+
+/**
+ * Returns {@link react-native-theoplayer!THEOplayer.duration | the player's current time}, automatically updating whenever it changes.
+ *
+ * This hook must only be used in a component mounted inside a {@link THEOplayerDefaultUi} or {@link UiContainer},
+ * or alternatively any other component that provides a {@link PlayerContext}.
+ *
+ * @group Hooks
+ */
+export const useCurrentTime = () => {
+  const player = useContext(PlayerContext).player;
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      TIME_CHANGE_EVENTS.forEach((event) => player?.addEventListener(event, callback));
+      return () => TIME_CHANGE_EVENTS.forEach((event) => player?.removeEventListener(event, callback));
+    },
+    [player],
+  );
+  return useSyncExternalStore(subscribe, () => (player ? player.currentTime : 0));
+};

--- a/src/ui/components/hooks/useCurrentTime.ts
+++ b/src/ui/components/hooks/useCurrentTime.ts
@@ -15,7 +15,7 @@ const TIME_CHANGE_EVENTS = [PlayerEventType.TIME_UPDATE, PlayerEventType.SEEKING
  * @group Hooks
  */
 export const useCurrentTime = () => {
-  const player = useContext(PlayerContext).player;
+  const { player } = useContext(PlayerContext);
   const subscribe = useCallback(
     (callback: () => void) => {
       TIME_CHANGE_EVENTS.forEach((event) => player?.addEventListener(event, callback));

--- a/src/ui/components/hooks/useDebounce.ts
+++ b/src/ui/components/hooks/useDebounce.ts
@@ -1,0 +1,20 @@
+import { useCallback, useRef } from 'react';
+
+export function useDebounce<T>(func: (value: T) => void, delay: number) {
+  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+  return useCallback(
+    (value: T, force?: boolean) => {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = undefined;
+      if (force) {
+        func(value);
+      } else {
+        timeoutRef.current = setTimeout(() => {
+          timeoutRef.current = undefined;
+          func(value);
+        }, delay);
+      }
+    },
+    [func, delay],
+  );
+}

--- a/src/ui/components/hooks/useDuration.ts
+++ b/src/ui/components/hooks/useDuration.ts
@@ -1,0 +1,25 @@
+import { useCallback, useContext, useSyncExternalStore } from 'react';
+import { PlayerContext } from '@theoplayer/react-native-ui';
+import { type PlayerEventMap, PlayerEventType } from 'react-native-theoplayer';
+
+const DURATION_CHANGE_EVENTS = [PlayerEventType.LOADED_DATA, PlayerEventType.DURATION_CHANGE] satisfies ReadonlyArray<keyof PlayerEventMap>;
+
+/**
+ * Returns {@link react-native-theoplayer!THEOplayer.duration | the player's duration}, automatically updating whenever it changes.
+ *
+ * This hook must only be used in a component mounted inside a {@link THEOplayerDefaultUi} or {@link UiContainer},
+ * or alternatively any other component that provides a {@link PlayerContext}.
+ *
+ * @group Hooks
+ */
+export const useDuration = () => {
+  const player = useContext(PlayerContext).player;
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      DURATION_CHANGE_EVENTS.forEach((event) => player?.addEventListener(event, callback));
+      return () => DURATION_CHANGE_EVENTS.forEach((event) => player?.removeEventListener(event, callback));
+    },
+    [player],
+  );
+  return useSyncExternalStore(subscribe, () => (player ? player.duration : NaN));
+};

--- a/src/ui/components/hooks/useDuration.ts
+++ b/src/ui/components/hooks/useDuration.ts
@@ -13,7 +13,7 @@ const DURATION_CHANGE_EVENTS = [PlayerEventType.LOADED_DATA, PlayerEventType.DUR
  * @group Hooks
  */
 export const useDuration = () => {
-  const player = useContext(PlayerContext).player;
+  const { player } = useContext(PlayerContext);
   const subscribe = useCallback(
     (callback: () => void) => {
       DURATION_CHANGE_EVENTS.forEach((event) => player?.addEventListener(event, callback));

--- a/src/ui/components/hooks/useSeekable.ts
+++ b/src/ui/components/hooks/useSeekable.ts
@@ -1,0 +1,26 @@
+import { useContext, useEffect, useState } from 'react';
+import { PlayerContext } from '@theoplayer/react-native-ui';
+import { PlayerEventType, type TimeRange, ProgressEvent } from 'react-native-theoplayer';
+
+/**
+ * Returns {@link react-native-theoplayer!THEOplayer.seekable | the player's seekable range}, automatically updating whenever it changes.
+ *
+ * This hook must only be used in a component mounted inside a {@link THEOplayerDefaultUi} or {@link UiContainer},
+ * or alternatively any other component that provides a {@link PlayerContext}.
+ *
+ * @group Hooks
+ */
+export const useSeekable = () => {
+  const player = useContext(PlayerContext).player;
+  const [seekable, setSeekable] = useState<TimeRange[]>([]);
+  useEffect(() => {
+    const onUpdateSeekable = (event: ProgressEvent) => {
+      setSeekable(event.seekable ?? player?.seekable ?? []);
+    };
+    player?.addEventListener(PlayerEventType.PROGRESS, onUpdateSeekable);
+    return () => {
+      player?.removeEventListener(PlayerEventType.PROGRESS, onUpdateSeekable);
+    };
+  }, [player]);
+  return seekable;
+};

--- a/src/ui/components/hooks/useSeekable.ts
+++ b/src/ui/components/hooks/useSeekable.ts
@@ -11,7 +11,7 @@ import { PlayerEventType, type TimeRange, ProgressEvent } from 'react-native-the
  * @group Hooks
  */
 export const useSeekable = () => {
-  const player = useContext(PlayerContext).player;
+  const { player } = useContext(PlayerContext);
   const [seekable, setSeekable] = useState<TimeRange[]>([]);
   useEffect(() => {
     const onUpdateSeekable = (event: ProgressEvent) => {

--- a/src/ui/components/hooks/useThumbnailTrack.ts
+++ b/src/ui/components/hooks/useThumbnailTrack.ts
@@ -1,0 +1,25 @@
+import { useCallback, useContext, useSyncExternalStore } from 'react';
+import { PlayerContext } from '@theoplayer/react-native-ui';
+import { PlayerEventType, filterThumbnailTracks, type PlayerEventMap } from 'react-native-theoplayer';
+
+const TEXT_TRACK_CHANGE_EVENTS = [PlayerEventType.LOADED_DATA, PlayerEventType.TEXT_TRACK_LIST] satisfies ReadonlyArray<keyof PlayerEventMap>;
+
+/**
+ * Returns a thumbnail track, if available.
+ *
+ * This hook must only be used in a component mounted inside a {@link THEOplayerDefaultUi} or {@link UiContainer},
+ * or alternatively any other component that provides a {@link PlayerContext}.
+ *
+ * @group Hooks
+ */
+export const useThumbnailTrack = () => {
+  const player = useContext(PlayerContext).player;
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      TEXT_TRACK_CHANGE_EVENTS.forEach((event) => player?.addEventListener(event, callback));
+      return () => TEXT_TRACK_CHANGE_EVENTS.forEach((event) => player?.removeEventListener(event, callback));
+    },
+    [player],
+  );
+  return useSyncExternalStore(subscribe, () => filterThumbnailTracks(player.textTracks));
+};

--- a/src/ui/components/hooks/useThumbnailTrack.ts
+++ b/src/ui/components/hooks/useThumbnailTrack.ts
@@ -13,7 +13,7 @@ const TEXT_TRACK_CHANGE_EVENTS = [PlayerEventType.LOADED_DATA, PlayerEventType.T
  * @group Hooks
  */
 export const useThumbnailTrack = () => {
-  const player = useContext(PlayerContext).player;
+  const { player } = useContext(PlayerContext);
   const subscribe = useCallback(
     (callback: () => void) => {
       TEXT_TRACK_CHANGE_EVENTS.forEach((event) => player?.addEventListener(event, callback));

--- a/src/ui/components/seekbar/SeekBar.tsx
+++ b/src/ui/components/seekbar/SeekBar.tsx
@@ -64,7 +64,7 @@ export const SeekBar = (props: SeekBarProps) => {
     debounceSeek(value[0], true);
   };
 
-  const normalizedDuration = isNaN(duration) || !isFinite(duration) ? 0 : duration;
+  const normalizedDuration = isNaN(duration) || !isFinite(duration) ? 0 : Math.max(0, duration);
   const seekableStart = seekable.length > 0 ? seekable[0].start : 0;
   const seekableEnd = seekable.length > 0 ? seekable[0].end : normalizedDuration;
 
@@ -76,16 +76,20 @@ export const SeekBar = (props: SeekBarProps) => {
           onLayout={(event: LayoutChangeEvent) => {
             setWidth(event.nativeEvent.layout.width);
           }}>
-          {isScrubbing && (
-            <SingleThumbnailView seekableStart={seekableStart} seekableEnd={seekableEnd} currentTime={sliderTime} seekBarWidth={width} />
-          )}
           <Slider
             disabled={(!(duration > 0) && seekable.length > 0) || context.adInProgress}
             minimumValue={seekableStart}
             maximumValue={seekableEnd}
-            containerStyle={props.sliderContainerStyle ?? {}}
+            containerStyle={props.sliderContainerStyle ?? { marginHorizontal: 8 }}
             maximumTrackStyle={props.sliderMaximumTrackStyle ?? {}}
             step={1000}
+            renderAboveThumbComponent={(_index: number, value: number) => {
+              return (
+                isScrubbing && (
+                  <SingleThumbnailView seekableStart={seekableStart} seekableEnd={seekableEnd} currentTime={value} seekBarWidth={width} />
+                )
+              );
+            }}
             onSlidingStart={onSlidingStart}
             onValueChange={onSlidingValueChange}
             onSlidingComplete={onSlidingComplete}

--- a/src/ui/components/seekbar/SeekBar.tsx
+++ b/src/ui/components/seekbar/SeekBar.tsx
@@ -86,7 +86,7 @@ export const SeekBar = (props: SeekBarProps) => {
             onSlidingStart={onSlidingStart}
             onValueChange={onSlidingValueChange}
             onSlidingComplete={onSlidingComplete}
-            value={sliderTime}
+            value={isScrubbing && scrubberTime !== undefined ? scrubberTime : sliderTime}
             minimumTrackTintColor={context.style.colors.seekBarMinimum}
             maximumTrackTintColor={context.style.colors.seekBarMaximum}
             thumbTintColor={context.style.colors.seekBarDot}

--- a/src/ui/components/seekbar/SeekBar.tsx
+++ b/src/ui/components/seekbar/SeekBar.tsx
@@ -4,9 +4,9 @@ import { PlayerContext, UiContext } from '../util/PlayerContext';
 import { Slider } from '@miblanchard/react-native-slider';
 import { useDuration } from '../hooks/useDuration';
 import { useSeekable } from '../hooks/useSeekable';
-import { useCurrentTime } from '../hooks/useCurrentTime';
 import { useDebounce } from '../hooks/useDebounce';
 import { SingleThumbnailView } from './thumbnail/SingleThumbnailView';
+import { useSliderTime } from './useSliderTime';
 
 export interface SeekBarProps {
   /**
@@ -31,7 +31,7 @@ export const SeekBar = (props: SeekBarProps) => {
   const [width, setWidth] = useState(0);
   const duration = useDuration();
   const seekable = useSeekable();
-  const currentTime = useCurrentTime();
+  const currentTime = useSliderTime();
 
   useEffect(() => {
     // Set sliderTime based on currentTime changes

--- a/src/ui/components/seekbar/thumbnail/SingleThumbnailView.tsx
+++ b/src/ui/components/seekbar/thumbnail/SingleThumbnailView.tsx
@@ -1,8 +1,8 @@
 import { Dimensions, View } from 'react-native';
-import { filterThumbnailTracks } from 'react-native-theoplayer';
 import { PlayerContext } from '../../util/PlayerContext';
 import { ThumbnailView } from './ThumbnailView';
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
+import { useThumbnailTrack } from '../../hooks/useThumbnailTrack';
 
 export interface ThumbnailViewProps {
   seekableStart: number;
@@ -13,12 +13,15 @@ export interface ThumbnailViewProps {
 
 export function SingleThumbnailView(props: ThumbnailViewProps) {
   const player = useContext(PlayerContext).player;
-  const thumbnailTrack = filterThumbnailTracks(player.textTracks);
+  const thumbnailTrack = useThumbnailTrack();
+
   if (!thumbnailTrack) {
     return <></>;
   }
-  const window = Dimensions.get('window');
-  const thumbnailSize = 0.35 * Math.min(window.height, window.width);
+  const thumbnailSize = useMemo(() => {
+    const window = Dimensions.get('window');
+    return 0.35 * Math.min(window.height, window.width);
+  }, []);
 
   const { seekableStart, seekableEnd, currentTime, seekBarWidth } = props;
   const percentageOffset = (currentTime - seekableStart) / (seekableEnd - seekableStart);

--- a/src/ui/components/seekbar/thumbnail/SingleThumbnailView.tsx
+++ b/src/ui/components/seekbar/thumbnail/SingleThumbnailView.tsx
@@ -24,19 +24,20 @@ export function SingleThumbnailView(props: ThumbnailViewProps) {
   }, []);
 
   const { seekableStart, seekableEnd, currentTime, seekBarWidth } = props;
+  const marginHorizontal = 8;
 
   // Do not let the thumbnail pass left & right borders.
   const seekableRange = seekableEnd - seekableStart;
   const offset = seekableRange ? (seekBarWidth * (currentTime - seekableStart)) / seekableRange : 0;
   let left = -0.5 * thumbnailSize;
-  if (offset < 0.5 * thumbnailSize) {
-    left = -offset;
-  } else if (offset > seekBarWidth - 0.5 * thumbnailSize) {
-    left = -offset + seekBarWidth - thumbnailSize;
+  if (offset + marginHorizontal < 0.5 * thumbnailSize) {
+    left = -offset - marginHorizontal;
+  } else if (offset - marginHorizontal > seekBarWidth - 0.5 * thumbnailSize) {
+    left = -offset + marginHorizontal + seekBarWidth - thumbnailSize;
   }
 
   return (
-    <View style={{ left, marginHorizontal: 8 }}>
+    <View style={{ left, marginHorizontal }}>
       <ThumbnailView thumbnailTrack={thumbnailTrack} duration={player.duration} time={currentTime} size={thumbnailSize} showTimeLabel={false} />
     </View>
   );

--- a/src/ui/components/seekbar/thumbnail/SingleThumbnailView.tsx
+++ b/src/ui/components/seekbar/thumbnail/SingleThumbnailView.tsx
@@ -24,17 +24,19 @@ export function SingleThumbnailView(props: ThumbnailViewProps) {
   }, []);
 
   const { seekableStart, seekableEnd, currentTime, seekBarWidth } = props;
-  const percentageOffset = (currentTime - seekableStart) / (seekableEnd - seekableStart);
-  const marginHorizontal = 10;
+
+  // Do not let the thumbnail pass left & right borders.
+  const seekableRange = seekableEnd - seekableStart;
+  const offset = seekableRange ? (seekBarWidth * (currentTime - seekableStart)) / seekableRange : 0;
+  let left = -0.5 * thumbnailSize;
+  if (offset < 0.5 * thumbnailSize) {
+    left = -offset;
+  } else if (offset > seekBarWidth - 0.5 * thumbnailSize) {
+    left = -offset + seekBarWidth - thumbnailSize;
+  }
 
   return (
-    <View
-      style={{
-        position: 'absolute',
-        top: -(thumbnailSize * 0.6),
-        left: Math.max(0, Math.min(seekBarWidth - thumbnailSize - marginHorizontal, percentageOffset * seekBarWidth - 0.5 * thumbnailSize)),
-        marginHorizontal,
-      }}>
+    <View style={{ left, marginHorizontal: 8 }}>
       <ThumbnailView thumbnailTrack={thumbnailTrack} duration={player.duration} time={currentTime} size={thumbnailSize} showTimeLabel={false} />
     </View>
   );

--- a/src/ui/components/seekbar/useSliderTime.ts
+++ b/src/ui/components/seekbar/useSliderTime.ts
@@ -1,0 +1,6 @@
+import { useCurrentTime } from '../hooks/useCurrentTime';
+
+export const useSliderTime = () => {
+  const currentTime = useCurrentTime();
+  return Number.isFinite(currentTime) ? Math.round(currentTime * 1e-3) * 1e3 : 0;
+};


### PR DESCRIPTION
Drop dependency on @react-native-community/slider and replace with @miblanchard/react-native-slider, which is commonly-used a slider implementation in react-native without any native dependencies, available on all platforms (including tvOS).

Also fix the slider crash for live streams passing NaN or Infinite values.