### PR TITLE
Bugfix/hook loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue for Web where the `SeekBar` component would throw an infinite loop error on Safari browsers.
+
 ## 0.10.0 (2025-01-22)
 
 ### Changed


### PR DESCRIPTION
On Safari browsers, the useCurrentTime hook would throw a `Error: Maximum update depth exceeded. The result of getSnapshot should be cached to avoid an infinite loop.` error, because the getSnapshot result would differ from store result.
Replaced the `useSyncExternalStore` hook with `useState`.