### PR TITLE
Feature/chapter markers

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -62,19 +62,26 @@ export default function App() {
     player.source = {
       sources: [
         {
-          src: 'https://cdn.theoplayer.com/video/dash/bbb_30fps/bbb_with_multiple_tiled_thumbnails.mpd',
-          type: 'application/dash+xml',
+          src: 'https://cdn.theoplayer.com/video/sintel/nosubs.m3u8',
+          type: 'application/x-mpegurl',
         },
       ],
-      poster: 'https://cdn.theoplayer.com/video/big_buck_bunny/poster.jpg',
       metadata: {
-        title: 'Big Buck Bunny',
-        subtitle: 'DASH - Thumbnails in manifest',
+        title: 'Sintel',
+        subtitle: 'HLS - Sideloaded Chapters',
         album: 'React-Native THEOplayer demos',
         mediaUri: 'https://theoplayer.com',
-        displayIconUri: 'https://cdn.theoplayer.com/video/big_buck_bunny/poster.jpg',
+        displayIconUri: 'https://cdn.theoplayer.com/video/sintel_old/poster.jpg',
         artist: 'THEOplayer',
       },
+      textTracks: [{
+        kind: TextTrackKind.chapters,
+        src: 'https://cdn.theoplayer.com/video/sintel/chapters.vtt',
+        format: 'webvtt',
+        srclang: 'en',
+        label: 'Chapters',
+        default: true
+      }],
     };
 
     player.muted = true;

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -141,7 +141,7 @@ export default function App() {
                   <ControlBar>
                     <MuteButton />
                     <TimeLabel showDuration={true} />
-                    <ChapterLabel fadeOut={false} />
+                    <ChapterLabel />
                     <Spacer />
                     <PipButton />
                     <FullscreenButton />

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -19,8 +19,9 @@ import {
   Spacer,
   TimeLabel,
   UiContainer,
+  ChapterLabel
 } from '@theoplayer/react-native-ui';
-import { PlayerConfiguration, PlayerEventType, THEOplayer, THEOplayerView } from 'react-native-theoplayer';
+import { PlayerConfiguration, PlayerEventType, TextTrackKind, THEOplayer, THEOplayerView } from 'react-native-theoplayer';
 
 import { Platform, StyleSheet, View, ViewStyle } from 'react-native';
 import { AdDisplay } from '@theoplayer/react-native-ui';
@@ -132,6 +133,7 @@ export default function App() {
                   <ControlBar>
                     <MuteButton />
                     <TimeLabel showDuration={true} />
+                    <ChapterLabel fadeOut={false} />
                     <Spacer />
                     <PipButton />
                     <FullscreenButton />

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -136,7 +136,7 @@ export default function App() {
               bottom={
                 <>
                   <ControlBar>
-                    <SeekBar />
+                    <SeekBar chapterMarkers={() => (<SquareMarker/>)} />
                   </ControlBar>
                   <ControlBar>
                     <MuteButton />

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -40,6 +40,14 @@ const playerConfig: PlayerConfiguration = {
   mutedAutoplay: 'all',
 };
 
+const SquareMarker = () => {
+  return <View style={{
+    width: 5,
+    height: 4,
+    backgroundColor: "yellow",
+  }} />;
+};
+
 /**
  * The example app demonstrates the use of the THEOplayerView with a custom UI using the provided UI components.
  * If you don't want to create a custom UI, you can just use the THEOplayerDefaultUi component instead.

--- a/src/ui/components/barrel.ts
+++ b/src/ui/components/barrel.ts
@@ -6,5 +6,6 @@ export * from './menu/barrel';
 export * from './message/barrel';
 export * from './seekbar/barrel';
 export * from './timelabel/barrel';
+export * from './chapterlabel/barrel'
 export * from './uicontroller/barrel';
 export * from './util/barrel';

--- a/src/ui/components/chapterlabel/ChapterLabel.tsx
+++ b/src/ui/components/chapterlabel/ChapterLabel.tsx
@@ -1,6 +1,6 @@
 import type { StyleProp, TextStyle } from 'react-native';
 import { Text } from 'react-native'
-import React, { PureComponent, useCallback, useContext, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import { PlayerEventType, TimeUpdateEvent } from 'react-native-theoplayer';
 import { PlayerContext, UiContext } from '../util/PlayerContext';
 import { useChaptersTrack } from '../../hooks/useChaptersTrack';

--- a/src/ui/components/chapterlabel/ChapterLabel.tsx
+++ b/src/ui/components/chapterlabel/ChapterLabel.tsx
@@ -8,10 +8,6 @@ import { usePlayerEvent } from '../../hooks/usePlayerEvent';
 
 export interface ChapterLabelProps {
   /**
-   * Whether to fade out after a seek.
-   */
-  fadeOut: boolean;
-  /**
    * The style overrides.
    */
   style?: StyleProp<TextStyle>;

--- a/src/ui/components/chapterlabel/ChapterLabel.tsx
+++ b/src/ui/components/chapterlabel/ChapterLabel.tsx
@@ -1,0 +1,60 @@
+import type { StyleProp, TextStyle } from 'react-native';
+import { Text } from 'react-native'
+import React, { PureComponent, useCallback, useContext, useState } from 'react';
+import { PlayerEventType, TimeUpdateEvent } from 'react-native-theoplayer';
+import { PlayerContext, UiContext } from '../util/PlayerContext';
+import { useChaptersTrack } from '../../hooks/useChaptersTrack';
+import { usePlayerEvent } from '../../hooks/usePlayerEvent';
+
+export interface ChapterLabelProps {
+  /**
+   * Whether to fade out after a seek.
+   */
+  fadeOut: boolean;
+  /**
+   * The style overrides.
+   */
+  style?: StyleProp<TextStyle>;
+}
+
+export interface ChapterLabelState {
+  currentTime: number;
+}
+
+/**
+ * The default style for the time label.
+ */
+export const DEFAULT_CHAPTER_LABEL_STYLE: TextStyle = {
+  marginLeft: 10,
+  marginRight: 10,
+  height: 20,
+  alignSelf: 'center',
+};
+
+/**
+ * The default time label component for the `react-native-theoplayer` UI.
+ */
+
+
+export const ChapterLabel = (props: ChapterLabelProps) => {
+    const player = useContext(PlayerContext).player;
+    const [currentTime, setCurrentTime] = useState(0);
+    const chapters = useChaptersTrack()
+    const onTimeUpdate = useCallback(
+        (event?: TimeUpdateEvent) => {
+            if (!event) return;
+            const { currentTime } = event
+            setCurrentTime(currentTime);
+        },
+        [],
+    );  
+    usePlayerEvent(player, PlayerEventType.TIME_UPDATE, onTimeUpdate, [onTimeUpdate]);  
+    const currentChapter = chapters?.cues?.find(cue => (cue.startTime <= currentTime && cue.endTime > currentTime))
+    const label = currentChapter?.content
+    const { style } = props;
+    return (
+        <PlayerContext.Consumer>
+            {(context: UiContext) => <Text style={[context.style.text, { color: context.style.colors.text }, style]}>{label}</Text>}
+        </PlayerContext.Consumer>
+        );
+}

--- a/src/ui/components/chapterlabel/barrel.ts
+++ b/src/ui/components/chapterlabel/barrel.ts
@@ -1,0 +1,1 @@
+export * from './ChapterLabel';

--- a/src/ui/components/seekbar/SeekBar.tsx
+++ b/src/ui/components/seekbar/SeekBar.tsx
@@ -8,6 +8,7 @@ import { useDebounce } from '../../hooks/useDebounce';
 import { SingleThumbnailView } from './thumbnail/SingleThumbnailView';
 import { useSliderTime } from './useSliderTime';
 import { TestIDs } from '../../utils/TestIDs';
+import { useChaptersTrack } from '../../hooks/useChaptersTrack';
 
 export interface SeekBarProps {
   /**
@@ -39,6 +40,15 @@ export interface SeekBarProps {
  */
 const DEBOUNCE_SEEK_DELAY = 250;
 
+const Square = () => {
+  return <View style={{
+    width: 5,
+    height: 5,
+    backgroundColor: "yellow",
+  }} />;
+};
+
+
 export const SeekBar = (props: SeekBarProps) => {
   const player = useContext(PlayerContext).player;
   const [isScrubbing, setIsScrubbing] = useState(false);
@@ -47,7 +57,11 @@ export const SeekBar = (props: SeekBarProps) => {
   const duration = useDuration();
   const seekable = useSeekable();
   const sliderTime = useSliderTime();
-
+  const chapters = useChaptersTrack()
+  let chapterMarkerTimes: number[] = []
+  if (chapters && chapters?.cues) {
+    chapterMarkerTimes = chapters?.cues.map(cue => cue.endTime).slice(0,-1)
+  } 
   // Do not continuously seek while dragging the slider
   const debounceSeek = useDebounce((value: number) => {
     player.currentTime = value;
@@ -107,6 +121,8 @@ export const SeekBar = (props: SeekBarProps) => {
             minimumTrackTintColor={context.style.colors.seekBarMinimum}
             maximumTrackTintColor={context.style.colors.seekBarMaximum}
             thumbTintColor={context.style.colors.seekBarDot}
+            renderTrackMarkComponent={() => (<Square/>)}
+            trackMarks={chapterMarkerTimes}
           />
         </View>
       )}

--- a/src/ui/components/seekbar/SeekBar.tsx
+++ b/src/ui/components/seekbar/SeekBar.tsx
@@ -27,6 +27,10 @@ export interface SeekBarProps {
    * Optional style applied to the track right of the thumb.
    */
   sliderMaximumTrackStyle?: ViewStyle;
+  /** 
+  * Optional 
+  */
+  chapterMarkers?: (index?: number) => React.ReactNode
   /**
    * An id used to locate this view in end-to-end tests.
    *
@@ -113,7 +117,7 @@ export const SeekBar = (props: SeekBarProps) => {
             minimumTrackTintColor={context.style.colors.seekBarMinimum}
             maximumTrackTintColor={context.style.colors.seekBarMaximum}
             thumbTintColor={context.style.colors.seekBarDot}
-            renderTrackMarkComponent={() => (<Square/>)}
+            renderTrackMarkComponent={props.chapterMarkers}
             trackMarks={chapterMarkerTimes}
           />
         </View>

--- a/src/ui/components/seekbar/SeekBar.tsx
+++ b/src/ui/components/seekbar/SeekBar.tsx
@@ -40,14 +40,6 @@ export interface SeekBarProps {
  */
 const DEBOUNCE_SEEK_DELAY = 250;
 
-const Square = () => {
-  return <View style={{
-    width: 5,
-    height: 5,
-    backgroundColor: "yellow",
-  }} />;
-};
-
 
 export const SeekBar = (props: SeekBarProps) => {
   const player = useContext(PlayerContext).player;

--- a/src/ui/hooks/useChaptersTrack.ts
+++ b/src/ui/hooks/useChaptersTrack.ts
@@ -8,7 +8,6 @@ const TEXT_TRACK_CHANGE_EVENTS = [PlayerEventType.LOADED_DATA, PlayerEventType.T
  * Retain first chapters track encountered in the textTracks list.
  */
 export function filterChaptersTrack(textTracks: TextTrack[] | undefined): TextTrack | undefined {
-    console.log('textTracks ', textTracks)
     return textTracks && textTracks.find(isChaptersTrack);
   }
   

--- a/src/ui/hooks/useChaptersTrack.ts
+++ b/src/ui/hooks/useChaptersTrack.ts
@@ -1,0 +1,41 @@
+import { useCallback, useContext, useSyncExternalStore } from 'react';
+import { PlayerContext } from '@theoplayer/react-native-ui';
+import { PlayerEventType, type PlayerEventMap } from 'react-native-theoplayer';
+import { TextTrack } from 'react-native-theoplayer'
+
+const TEXT_TRACK_CHANGE_EVENTS = [PlayerEventType.LOADED_DATA, PlayerEventType.TEXT_TRACK_LIST] satisfies ReadonlyArray<keyof PlayerEventMap>;
+
+/**
+ * Retain first chapters track encountered in the textTracks list.
+ */
+export function filterChaptersTrack(textTracks: TextTrack[] | undefined): TextTrack | undefined {
+    console.log('textTracks ', textTracks)
+    return textTracks && textTracks.find(isChaptersTrack);
+  }
+  
+  /**
+   * Query whether a track is a valid chapters track.
+   */
+  export function isChaptersTrack(textTrack: TextTrack | undefined): boolean {
+    return !!textTrack && (textTrack.kind === 'chapters');
+  }
+
+/**
+ * Returns a chapters track, if available.
+ *
+ * This hook must only be used in a component mounted inside a {@link THEOplayerDefaultUi} or {@link UiContainer},
+ * or alternatively any other component that provides a {@link PlayerContext}.
+ *
+ * @group Hooks
+ */
+export const useChaptersTrack = () => {
+  const { player } = useContext(PlayerContext);
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      TEXT_TRACK_CHANGE_EVENTS.forEach((event) => player?.addEventListener(event, callback));
+      return () => TEXT_TRACK_CHANGE_EVENTS.forEach((event) => player?.removeEventListener(event, callback));
+    },
+    [player],
+  );
+  return useSyncExternalStore(subscribe, () => filterChaptersTrack(player.textTracks));
+};

--- a/src/ui/hooks/useChaptersTrack.ts
+++ b/src/ui/hooks/useChaptersTrack.ts
@@ -1,7 +1,6 @@
 import { useCallback, useContext, useSyncExternalStore } from 'react';
 import { PlayerContext } from '@theoplayer/react-native-ui';
-import { PlayerEventType, type PlayerEventMap } from 'react-native-theoplayer';
-import { TextTrack } from 'react-native-theoplayer'
+import { PlayerEventType, type PlayerEventMap, TextTrack } from 'react-native-theoplayer';
 
 const TEXT_TRACK_CHANGE_EVENTS = [PlayerEventType.LOADED_DATA, PlayerEventType.TEXT_TRACK_LIST] satisfies ReadonlyArray<keyof PlayerEventMap>;
 

--- a/src/ui/hooks/usePlayerEvent.tsx
+++ b/src/ui/hooks/usePlayerEvent.tsx
@@ -1,0 +1,16 @@
+import { DependencyList, useEffect } from "react";
+import { PlayerEventMap, THEOplayer } from "react-native-theoplayer";
+
+export function usePlayerEvent<K extends keyof PlayerEventMap>(
+  player: THEOplayer | undefined,
+  event: K | K[],
+  onEvent: (event: PlayerEventMap[K]) => void,
+  dependencies: DependencyList = [],
+) {
+  useEffect(() => {
+    player?.addEventListener(event, onEvent);
+    return () => {
+      player?.removeEventListener(event, onEvent);
+    };
+  }, [player, ...dependencies]);
+}

--- a/src/ui/hooks/usePlayerEvent.tsx
+++ b/src/ui/hooks/usePlayerEvent.tsx
@@ -1,5 +1,5 @@
 import { DependencyList, useEffect } from "react";
-import { PlayerEventMap, THEOplayer } from "react-native-theoplayer";
+import type { PlayerEventMap, THEOplayer } from "react-native-theoplayer";
 
 export function usePlayerEvent<K extends keyof PlayerEventMap>(
   player: THEOplayer | undefined,


### PR DESCRIPTION
This PR adds support for chapter markers.

- An optional property `chapterMarkers` (signature `(index?: number) => React.ReactNode`) was added to the `SeekBar` component, to allow customers to provide a custom Component to render on the timeline per chapter mark index
- A new component `ChapterLabel` was introduced. It displays the current chapter name (based on `player.currentTime`) and there's a possibility to override the `TextStyle`.

For this feature to work on iOS, a change in [react-native-theoplayer](https://github.com/THEOplayer/react-native-theoplayer) needs to be available to parse the chapter vtt in the iOS bridge.