### PR TITLE
Bugfix/visibility fix

### DIFF
--- a/src/ui/components/uicontroller/UiContainer.tsx
+++ b/src/ui/components/uicontroller/UiContainer.tsx
@@ -187,7 +187,7 @@ export const UiContainer = (props: UiContainerProps) => {
   const _currentFadeOutTimeout = useRef<number | undefined>(undefined);
   const fadeAnimation = useRef(new Animated.Value(1)).current;
   const [currentMenu, setCurrentMenu] = useState<React.ReactNode | undefined>(undefined);
-  const [showing, setShowing] = useState(true);
+  const [isPassingPointerEvents, setIsPassingPointerEvents] = useState(true);
   const [buttonsEnabled_, setButtonsEnabled] = useState(true);
   const [error, setError] = useState<PlayerError | undefined>(undefined);
   const [firstPlay, setFirstPlay] = useState(false);
@@ -331,7 +331,7 @@ export const UiContainer = (props: UiContainerProps) => {
       toValue: 0,
       duration: 0,
     }).start(() => {
-      setShowing(false);
+      setIsPassingPointerEvents(false);
       player.presentationMode = PresentationMode.pip;
     });
   };
@@ -339,7 +339,7 @@ export const UiContainer = (props: UiContainerProps) => {
   const stopAnimationsAndShowUi_ = () => {
     clearTimeout(_currentFadeOutTimeout.current);
     _currentFadeOutTimeout.current = undefined;
-    if (!showing) {
+    if (!isPassingPointerEvents) {
       doFadeIn_();
     }
   };
@@ -358,7 +358,7 @@ export const UiContainer = (props: UiContainerProps) => {
   };
 
   const doFadeIn_ = () => {
-    setShowing(true);
+    setIsPassingPointerEvents(true);
     Animated.timing(fadeAnimation, {
       useNativeDriver: true,
       toValue: 1,
@@ -379,7 +379,7 @@ export const UiContainer = (props: UiContainerProps) => {
       toValue: 0,
       duration: 200,
     }).start(() => {
-      setShowing(false);
+      setIsPassingPointerEvents(false);
     });
   };
 
@@ -425,7 +425,7 @@ export const UiContainer = (props: UiContainerProps) => {
         <Animated.View
           style={[combinedUiContainerStyle, { opacity: fadeAnimation }]}
           onTouchStart={onUserAction_}
-          pointerEvents={showing ? 'auto' : 'box-only'}
+          pointerEvents={isPassingPointerEvents ? 'auto' : 'box-only'}
           {...(Platform.OS === 'web' ? { onMouseMove: onUserAction_, onMouseLeave: doFadeOut_ } : {})}>
           <>
             {/* The UI background */}

--- a/src/ui/components/uicontroller/UiContainer.tsx
+++ b/src/ui/components/uicontroller/UiContainer.tsx
@@ -237,13 +237,14 @@ export const UiContainer = (props: UiContainerProps) => {
     };
 
     const handleEnded = () => {
-      setShowing(true);
+      stopAnimationsAndShowUi_();
     };
 
     const handlePresentationModeChange = (event: PresentationModeChangeEvent) => {
       setPip(event.presentationMode === PresentationMode.pip);
       if (event.presentationMode !== PresentationMode.pip) {
-        setShowing(true);
+        stopAnimationsAndShowUi_();
+        resumeAnimationsIfPossible_();
       }
     };
 


### PR DESCRIPTION
PR started as a fix for an issue noticed on iOS, where after closing pip, the ui could not be shown again correctly.
Main cause: the refactor done on the UIContainer assumed 'setShowing' would display the UI, but it only enables the pointerEvents processing. 
This PR serves as a fix for that issue, but while testing some issues were encountered with 'old state' being used, which was tackled by restructuring the hooks and their dependencies.

some prop/method name changes were made:
firstPlay -> didPlay
stopAnimationsAndShowUi_ -> fadeInUI_
resumeAnimationsIfPossible_ -> resumeUIFadeOut_