### PR TITLE
Feature/preview timelabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed the useEnded hook to take into account a currentTime that can become slightly larger than the expected stream duration.
 - Fixed an issue on Android where a thumbnail preview would contain multiple tiles when the tile image was larger than 2048px.
 
+### Added
+
+- Added a `renderAboveThumbComponent` property to the `SeekBar` component that allows customizing an optional component that is rendered above the `SeekBar`'s thumbnail. The `ThumbnailView` remains the default component.
+
 ## [0.14.0] (2025-07-04)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Prevent a fade out of the UI while the skip buttons are being used.
 - Fixed the useEnded hook to take into account a currentTime that can become slightly larger than the expected stream duration.
 - Fixed an issue on Android where a thumbnail preview would contain multiple tiles when the tile image was larger than 2048px.
+- Fixed an issue where `<TimeLabel>` would briefly show an invalid duration when playing a live stream.
 
 ### Added
 

--- a/src/ui/components/timelabel/StaticTimeLabel.tsx
+++ b/src/ui/components/timelabel/StaticTimeLabel.tsx
@@ -1,6 +1,6 @@
 import { StyleProp, Text, TextStyle } from 'react-native';
-import React from 'react';
-import { PlayerContext, UiContext } from '../util/PlayerContext';
+import React, { useContext } from 'react';
+import { PlayerContext } from '../util/PlayerContext';
 
 export interface StaticTimeLabelProps {
   /**
@@ -18,7 +18,7 @@ export interface StaticTimeLabelProps {
   /**
    * The duration of the current source.
    */
-  duration: number;
+  duration?: number;
 }
 
 /**
@@ -26,38 +26,37 @@ export interface StaticTimeLabelProps {
  */
 export function StaticTimeLabel(props: StaticTimeLabelProps) {
   const { style, showDuration, time, duration } = props;
+  const context = useContext(PlayerContext);
 
-  // An unknown duration is reported as NaN.
-  if (isNaN(duration)) {
+  // An invalid duration
+  if (showDuration && !isValidDuration(duration)) {
     return <></>;
   }
 
   // Live streams report an Infinity duration.
-  if (!isFinite(duration)) {
-    return (
-      <PlayerContext.Consumer>
-        {(context: UiContext) => (
-          <Text style={[context.style.text, { color: context.style.colors.text }, style]}>{context.locale.liveLabel}</Text>
-        )}
-      </PlayerContext.Consumer>
-    );
+  if (showDuration && isLiveDuration(duration)) {
+    return <Text style={[context.style.text, { color: context.style.colors.text }, style]}>{context.locale.liveLabel}</Text>;
   }
 
   try {
     let currentTimeLabel = new Date(time).toISOString().substring(11, 19);
-    let durationLabel = new Date(duration).toISOString().substring(11, 19);
+    let durationLabel = new Date(duration ?? 0).toISOString().substring(11, 19);
     if (durationLabel.startsWith('00:')) {
       // Don't render hours if not needed.
       currentTimeLabel = currentTimeLabel.slice(3);
       durationLabel = durationLabel.slice(3);
     }
     const label = showDuration ? `${currentTimeLabel} / ${durationLabel}` : currentTimeLabel;
-    return (
-      <PlayerContext.Consumer>
-        {(context: UiContext) => <Text style={[context.style.text, { color: context.style.colors.text }, style]}>{label}</Text>}
-      </PlayerContext.Consumer>
-    );
+    return <Text style={[context.style.text, { color: context.style.colors.text }, style]}>{label}</Text>;
   } catch {
     return <></>;
   }
+}
+
+function isValidDuration(duration: number | undefined): boolean {
+  return duration !== undefined && !isNaN(duration);
+}
+
+function isLiveDuration(duration: number | undefined): boolean {
+  return duration !== undefined && !isFinite(duration);
 }

--- a/src/ui/components/timelabel/StaticTimeLabel.tsx
+++ b/src/ui/components/timelabel/StaticTimeLabel.tsx
@@ -54,7 +54,7 @@ export function StaticTimeLabel(props: StaticTimeLabelProps) {
 }
 
 function isValidDuration(duration: number | undefined): boolean {
-  return duration !== undefined && !isNaN(duration);
+  return duration !== undefined && !isNaN(duration) && duration > 0;
 }
 
 function isLiveDuration(duration: number | undefined): boolean {

--- a/src/ui/components/timelabel/TimeLabel.tsx
+++ b/src/ui/components/timelabel/TimeLabel.tsx
@@ -1,8 +1,7 @@
 import type { StyleProp, TextStyle } from 'react-native';
-import React, { PureComponent } from 'react';
-import { DurationChangeEvent, PlayerEventType, TimeUpdateEvent } from 'react-native-theoplayer';
-import { PlayerContext, UiContext } from '../util/PlayerContext';
+import React from 'react';
 import { StaticTimeLabel } from './StaticTimeLabel';
+import { useCurrentTime, useDuration } from '../../hooks/barrel';
 
 export interface TimeLabelProps {
   /**
@@ -13,11 +12,6 @@ export interface TimeLabelProps {
    * The style overrides.
    */
   style?: StyleProp<TextStyle>;
-}
-
-export interface TimeLabelState {
-  currentTime: number;
-  duration: number;
 }
 
 /**
@@ -33,47 +27,9 @@ export const DEFAULT_TIME_LABEL_STYLE: TextStyle = {
 /**
  * The default time label component for the `react-native-theoplayer` UI.
  */
-export class TimeLabel extends PureComponent<TimeLabelProps, TimeLabelState> {
-  private static initialState: TimeLabelState = {
-    currentTime: 0.0,
-    duration: 0,
-  };
-
-  constructor(props: TimeLabelProps) {
-    super(props);
-    this.state = TimeLabel.initialState;
-  }
-
-  componentDidMount() {
-    const player = (this.context as UiContext).player;
-    player.addEventListener(PlayerEventType.TIME_UPDATE, this.onTimeUpdate);
-    player.addEventListener(PlayerEventType.DURATION_CHANGE, this.onDurationChange);
-    this.setState({ currentTime: player.currentTime, duration: player.duration });
-  }
-
-  componentWillUnmount() {
-    const player = (this.context as UiContext).player;
-    player.removeEventListener(PlayerEventType.TIME_UPDATE, this.onTimeUpdate);
-    player.removeEventListener(PlayerEventType.DURATION_CHANGE, this.onDurationChange);
-  }
-
-  private onTimeUpdate = (event: TimeUpdateEvent) => {
-    const { currentTime } = event;
-    this.setState({ currentTime });
-  };
-
-  private onDurationChange = (event: DurationChangeEvent) => {
-    const { duration } = event;
-    this.setState({ duration });
-  };
-
-  render() {
-    const { currentTime, duration } = this.state;
-    const { style, showDuration } = this.props;
-    return (
-      <StaticTimeLabel showDuration={showDuration} time={currentTime} duration={duration} style={[DEFAULT_TIME_LABEL_STYLE, style]}></StaticTimeLabel>
-    );
-  }
-}
-
-TimeLabel.contextType = PlayerContext;
+export const TimeLabel = (props: TimeLabelProps) => {
+  const currentTime = useCurrentTime();
+  const duration = useDuration();
+  const { showDuration, style } = props;
+  return <StaticTimeLabel showDuration={showDuration} time={currentTime} duration={duration} style={[DEFAULT_TIME_LABEL_STYLE, style]} />;
+};


### PR DESCRIPTION
Added a `renderAboveThumbComponent` property to the `SeekBar` component that allows customizing an optional component that is rendered above the `SeekBar`'s thumbnail. The `ThumbnailView` remains the default component.

Show for example a `StaticTimeLabel`, while scrubbing:

```
<SeekBar
  onScrubbing={setScrubTime}
  renderAboveThumbComponent={() => {
    return <StaticTimeLabel
      time={scrubTime ?? Number.NaN}
      showDuration={false}
      style={[DEFAULT_TIME_LABEL_STYLE, {left: -24}]}/>
  }} />
``` 
<img width="478" height="158" alt="Screenshot 2025-07-31 at 12 52 17" src="https://github.com/user-attachments/assets/6fdf9dbe-965f-4ff0-ad4e-af5acd2f9e25" />
