### PR TITLE
Bugfix/android thumbnail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Prevent a fade out of the UI while the skip buttons are being used. 
+- Prevent a fade out of the UI while the skip buttons are being used.
 - Fixed the useEnded hook to take into account a currentTime that can become slightly larger than the expected stream duration.
+- Fixed an issue on Android where a thumbnail preview would contain multiple tiles when the tile image was larger than 2048px.
 
 ## [0.14.0] (2025-07-04)
 


### PR DESCRIPTION
Fixed an issue on Android where a thumbnail preview would contain multiple tiles when the tile image was larger than 2048px.

On Android, Fresco can scale the React Native `<Image>` component internally if it is considered to be
'huge' (larger than 2048px width). There is no way to know the original size without using another
image package. This would break the fragment url values, e.g.:

```
big_buck_bunny_thumbnails.jpg#xywh=0,0,100,56
```

would contain 4 tile images at once.

The work-around calculates the maximum tile size based on all cue W3C Media Fragments URIs and adjusts the image size based on it.

Known React Native issue:
{@link https://github.com/facebook/react-native/issues/22145}