### PR TITLE
Follow AirPlay state change event for the AirPlay button

### DIFF
--- a/src/ui/hooks/useAirplay.ts
+++ b/src/ui/hooks/useAirplay.ts
@@ -15,7 +15,7 @@ export const useAirplay = () => {
   const [castState, setCastState] = useState(player.cast.airplay?.state ?? CastState.unavailable);
   useEffect(() => {
     const onCastStateChangeEvent = (event: CastEvent) => {
-      if (event.subType === CastEventType.CHROMECAST_STATE_CHANGE) {
+      if (event.subType === CastEventType.AIRPLAY_STATE_CHANGE) {
         setCastState(event.state);
       }
     };


### PR DESCRIPTION
This fixes an issue where both Chromecast and AirPlay buttons were shown as "connected" when using Chromecast.

Thanks @wvanhaevre for quickly finding the root cause!