### PR TITLE
Handle waiting event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed an issue where the `<CenteredDelayedActivityIndicator>` was not shown in all platforms when the `waiting` was fired.
 - Fixed an issue where high-frequency `progress` events would trigger excessive re-renders and cause memory buildup.
 
 ## [0.15.0] (2025-08-04)

--- a/src/ui/hooks/useWaiting.ts
+++ b/src/ui/hooks/useWaiting.ts
@@ -3,6 +3,7 @@ import { PlayerEventType, PlayerEventMap, ReadyStateChangeEvent, type Event } fr
 import { PlayerContext } from '../barrel';
 
 const WAITING_CHANGE_EVENTS = [
+  PlayerEventType.WAITING,
   PlayerEventType.READYSTATE_CHANGE,
   PlayerEventType.ERROR,
   PlayerEventType.PLAYING,
@@ -30,6 +31,9 @@ export const useWaiting = () => {
     const onUpdateWaiting = (event: Event<WaitingChangeEventType>) => {
       if (!player) return;
       switch (event.type) {
+        case PlayerEventType.WAITING:
+          setWaiting(!hasError && !player.paused);
+          break;
         case PlayerEventType.READYSTATE_CHANGE:
           setWaiting((event as ReadyStateChangeEvent).readyState < 3 && !hasError && !player.paused);
           break;


### PR DESCRIPTION
This fixes the spinner icon not showing up on iOS when the waiting event is fired.

Internal reference: https://opentelly.atlassian.net/browse/THEOSD-15902