### PR TITLE
Ignore default track labels

### DIFF
--- a/.changeset/curly-vans-sneeze.md
+++ b/.changeset/curly-vans-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/react-native-ui': patch
+---
+
+Improve labels for text tracks and audio tracks in the `<LanguageMenuView>`.

--- a/src/ui/components/menu/LanguageMenuButton.tsx
+++ b/src/ui/components/menu/LanguageMenuButton.tsx
@@ -6,7 +6,7 @@ import { LanguageSvg } from '../button/svg/LanguageSvg';
 import { ScrollableMenu } from './common/ScrollableMenu';
 import { MenuRadioButton } from './common/MenuRadioButton';
 import { MenuButton } from './common/MenuButton';
-import { filterRenderableTracks, getTrackLabel } from '../util/TrackUtils';
+import { filterRenderableTracks, getMediaTrackLabel, getTextTrackLabel } from '../util/TrackUtils';
 import { MenuView } from './common/MenuView';
 import type { StyleProp, ViewStyle } from 'react-native';
 
@@ -156,7 +156,7 @@ export class LanguageMenuView extends PureComponent<LanguageMenuViewProps, Langu
                     items={selectableAudioTracks.map((track, id) => (
                       <MenuRadioButton
                         key={id}
-                        label={getTrackLabel(track)}
+                        label={getMediaTrackLabel(track)}
                         uid={track.uid}
                         onSelect={this.selectAudioTrack}
                         selected={track.uid === selectedAudioTrack}></MenuRadioButton>
@@ -178,7 +178,7 @@ export class LanguageMenuView extends PureComponent<LanguageMenuViewProps, Langu
                         {selectableTextTracks.map((track, id) => (
                           <MenuRadioButton
                             key={id + 1}
-                            label={getTrackLabel(track)}
+                            label={getTextTrackLabel(track)}
                             uid={track.uid}
                             onSelect={this.onSelectTextTrack}
                             selected={track.uid === selectedTextTrack}

--- a/src/ui/components/util/TrackUtils.ts
+++ b/src/ui/components/util/TrackUtils.ts
@@ -3,13 +3,6 @@ import { TrackListEventType } from 'react-native-theoplayer';
 import { getISO639LanguageByCode } from '../../utils/language/Language';
 import type { QualityLabelLocaleParams } from './Locale';
 
-declare module 'react-native-theoplayer' {
-  interface TextTrack {
-    // TODO Remove after updating to THEOplayer 10.14.0.
-    captionChannel?: number;
-  }
-}
-
 export function getMediaTrackLabel(track: MediaTrack): string {
   const label = track.label;
   const languageCode = track.language;
@@ -47,7 +40,7 @@ export function getTextTrackLabel(track: TextTrack): string {
       return iso639Language.local;
     }
   }
-  if (track.type === 'cea608' && typeof track.captionChannel === 'number') {
+  if (track.type === 'cea608' && track.captionChannel !== undefined) {
     return `CC${track.captionChannel}`;
   }
   return languageCode || label || '';

--- a/src/ui/components/util/TrackUtils.ts
+++ b/src/ui/components/util/TrackUtils.ts
@@ -3,7 +3,21 @@ import { TrackListEventType } from 'react-native-theoplayer';
 import { getISO639LanguageByCode } from '../../utils/language/Language';
 import type { QualityLabelLocaleParams } from './Locale';
 
-export function getTrackLabel(track: MediaTrack | TextTrack): string {
+export function getMediaTrackLabel(track: MediaTrack): string {
+  if (track.label) {
+    return track.label;
+  }
+  const languageCode: string = track.language;
+  if (languageCode) {
+    const iso639Language = getISO639LanguageByCode(languageCode);
+    if (iso639Language) {
+      return iso639Language.local;
+    }
+  }
+  return languageCode || '';
+}
+
+export function getTextTrackLabel(track: TextTrack): string {
   if (track.label) {
     return track.label;
   }

--- a/src/ui/components/util/TrackUtils.ts
+++ b/src/ui/components/util/TrackUtils.ts
@@ -26,7 +26,7 @@ export function getMediaTrackLabel(track: MediaTrack): string {
       return iso639Language.local;
     }
   }
-  return languageCode || '';
+  return languageCode || label || '';
 }
 
 export function getTextTrackLabel(track: TextTrack): string {
@@ -50,7 +50,7 @@ export function getTextTrackLabel(track: TextTrack): string {
   if (track.type === 'cea608' && typeof track.captionChannel === 'number') {
     return `CC${track.captionChannel}`;
   }
-  return languageCode || '';
+  return languageCode || label || '';
 }
 
 export function stringFromTextTrackListEvent(type: TrackListEventType): string {

--- a/src/ui/components/util/TrackUtils.ts
+++ b/src/ui/components/util/TrackUtils.ts
@@ -3,6 +3,13 @@ import { TrackListEventType } from 'react-native-theoplayer';
 import { getISO639LanguageByCode } from '../../utils/language/Language';
 import type { QualityLabelLocaleParams } from './Locale';
 
+declare module 'react-native-theoplayer' {
+  interface TextTrack {
+    // TODO Remove after updating to THEOplayer 10.14.0.
+    captionChannel?: number;
+  }
+}
+
 export function getMediaTrackLabel(track: MediaTrack): string {
   const label = track.label;
   const languageCode = track.language;
@@ -39,6 +46,9 @@ export function getTextTrackLabel(track: TextTrack): string {
     if (iso639Language) {
       return iso639Language.local;
     }
+  }
+  if (track.type === 'cea608' && typeof track.captionChannel === 'number') {
+    return `CC${track.captionChannel}`;
   }
   return languageCode || '';
 }

--- a/src/ui/components/util/TrackUtils.ts
+++ b/src/ui/components/util/TrackUtils.ts
@@ -4,10 +4,15 @@ import { getISO639LanguageByCode } from '../../utils/language/Language';
 import type { QualityLabelLocaleParams } from './Locale';
 
 export function getMediaTrackLabel(track: MediaTrack): string {
-  if (track.label) {
-    return track.label;
+  const label = track.label;
+  const languageCode = track.language;
+  if (label) {
+    if (label === languageCode) {
+      // Ignore default label with just the language code.
+    } else {
+      return label;
+    }
   }
-  const languageCode: string = track.language;
   if (languageCode) {
     const iso639Language = getISO639LanguageByCode(languageCode);
     if (iso639Language) {
@@ -18,10 +23,17 @@ export function getMediaTrackLabel(track: MediaTrack): string {
 }
 
 export function getTextTrackLabel(track: TextTrack): string {
-  if (track.label) {
-    return track.label;
+  const label = track.label;
+  const languageCode = track.language;
+  if (label) {
+    if (label === languageCode) {
+      // Ignore default label with just the language code.
+    } else if (track.type === 'cea608' && /^CC\d+$/.test(track.label)) {
+      // Ignore default label with just the caption channel.
+    } else {
+      return label;
+    }
   }
-  const languageCode: string = track.language;
   if (languageCode) {
     const iso639Language = getISO639LanguageByCode(languageCode);
     if (iso639Language) {


### PR DESCRIPTION
THEOplayer sometimes sets `TextTrack.label` or `MediaTrack.label` to a default value, which can be:
* The localized language name, e.g. `"English"`
* The language code, e.g. `"en"`
* For CEA-608 closed captions: the caption channel number, e.g. `"CC1"`

This PR detects these "default labels" so we can replace them with our own logic. This will also allow THEOplayer to (eventually) stop localizing language names in the SDK itself, and instead delegate that to the UI logic.

This aligns with https://github.com/THEOplayer/android-ui/pull/84, https://github.com/THEOplayer/android-ui/pull/95 and https://github.com/THEOplayer/web-ui/pull/135.