### PR TITLE
Update to react-native-theoplayer 11.0 for development

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -4138,10 +4138,15 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.5",
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/batch": {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -15,7 +15,7 @@
         "react-native-safe-area-context": "^5.6.1",
         "react-native-svg": "^15.11.2",
         "react-native-svg-web": "^1.0.9",
-        "react-native-theoplayer": "^10.3.0",
+        "react-native-theoplayer": "^11.0.0",
         "react-native-web": "^0.20.0",
         "react-native-web-image-loader": "^0.1.1"
       },
@@ -38,7 +38,7 @@
         "copy-webpack-plugin": "^12.0.2",
         "eslint": "^8.57.1",
         "html-webpack-plugin": "^5.6.3",
-        "theoplayer": "^10",
+        "theoplayer": "^11",
         "typescript": "5.0.4",
         "webpack": "^5.95.0",
         "webpack-cli": "^5.1.4",
@@ -2861,10 +2861,12 @@
       }
     },
     "node_modules/@theoplayer/cmcd-connector-web": {
-      "version": "1.4.0",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@theoplayer/cmcd-connector-web/-/cmcd-connector-web-1.5.0.tgz",
+      "integrity": "sha512-eWElrE36ubYqaxcsc4iA8L1YwRB0m48rXl3OWjiQIZINdMUSyEB87999xEG9Y21WKVDCjG7yegnJzFBKnzttmQ==",
       "license": "MIT",
       "peerDependencies": {
-        "theoplayer": "^5 || ^6 || ^7 || ^8 || ^9 || ^10"
+        "theoplayer": "^5 || ^6 || ^7 || ^8 || ^9 || ^10 || ^11"
       }
     },
     "node_modules/@types/babel__core": {
@@ -6554,6 +6556,20 @@
       "version": "1.0.0",
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "devOptional": true,
@@ -10055,21 +10071,21 @@
       }
     },
     "node_modules/react-native-theoplayer": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/react-native-theoplayer/-/react-native-theoplayer-10.3.0.tgz",
-      "integrity": "sha512-+Cik+nFkuaDLL0KhmAJkK4xuuy7fnbpguWUlKC0Dj6dyauKIW+87PxMYqbEXyEPWwblUTqb5MEQrS38E6EWhYA==",
-      "license": "SEE LICENSE AT https://www.theoplayer.com/terms",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-theoplayer/-/react-native-theoplayer-11.0.0.tgz",
+      "integrity": "sha512-A8VkVJPUD4VrWAsS4HHI7+IcZBOireDl+1n0k7/sh1UKVDxX5KWXqA/acawYWpCn83BhsjmxPJRMYEYwJvgbNQ==",
+      "license": "BSD-3-Clause-Clear",
       "dependencies": {
-        "@theoplayer/cmcd-connector-web": "^1.4.0",
+        "@theoplayer/cmcd-connector-web": "^1.5.0",
         "buffer": "^6.0.3"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "peerDependencies": {
         "react": "*",
         "react-native": "*",
-        "theoplayer": "^9.12.0 || ^10"
+        "theoplayer": "^11"
       },
       "peerDependenciesMeta": {
         "theoplayer": {
@@ -11546,7 +11562,9 @@
       "license": "MIT"
     },
     "node_modules/theoplayer": {
-      "version": "10.0.1",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-11.0.0.tgz",
+      "integrity": "sha512-pxjpNtd++m87H5ndEPlNbKpHhXCNbFDgnXB0g6RfTv/v7zSpSLwiB0F0vIJe5asaqEJ6pKH7kvpTgnaEN2TElw==",
       "license": "SEE LICENSE AT https://www.theoplayer.com/terms"
     },
     "node_modules/thingies": {
@@ -11761,7 +11779,7 @@
     },
     "node_modules/typescript": {
       "version": "5.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/example/package.json
+++ b/example/package.json
@@ -19,7 +19,7 @@
     "react-native-safe-area-context": "^5.6.1",
     "react-native-svg": "^15.11.2",
     "react-native-svg-web": "^1.0.9",
-    "react-native-theoplayer": "^10.3.0",
+    "react-native-theoplayer": "^11.0.0",
     "react-native-web": "^0.20.0",
     "react-native-web-image-loader": "^0.1.1"
   },
@@ -42,7 +42,7 @@
     "copy-webpack-plugin": "^12.0.2",
     "eslint": "^8.57.1",
     "html-webpack-plugin": "^5.6.3",
-    "theoplayer": "^10",
+    "theoplayer": "^11",
     "typescript": "5.0.4",
     "webpack": "^5.95.0",
     "webpack-cli": "^5.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@theoplayer/react-native-ui",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@theoplayer/react-native-ui",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "SEE LICENSE AT https://www.theoplayer.com/terms",
       "dependencies": {
         "@miblanchard/react-native-slider": "^2.6.0",
@@ -31,7 +31,7 @@
         "react-native-builder-bob": "^0.39.1",
         "react-native-google-cast": "^4.8.3",
         "react-native-svg": "^15.8.0",
-        "react-native-theoplayer": "^10",
+        "react-native-theoplayer": "^11",
         "typedoc": "^0.25.13",
         "typedoc-plugin-external-resolver": "^1.0.3",
         "typedoc-plugin-mdn-links": "^3.3.4",
@@ -3424,13 +3424,13 @@
       }
     },
     "node_modules/@theoplayer/cmcd-connector-web": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@theoplayer/cmcd-connector-web/-/cmcd-connector-web-1.4.0.tgz",
-      "integrity": "sha512-fOl94/HKnJLiBwhy4KPLOtxcNksUHfCyXQTvTM0kVBdd+Y6DwgreGpk6RXeHpxzkVXgH0Sx1DjNutwfIqLk/yA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@theoplayer/cmcd-connector-web/-/cmcd-connector-web-1.5.0.tgz",
+      "integrity": "sha512-eWElrE36ubYqaxcsc4iA8L1YwRB0m48rXl3OWjiQIZINdMUSyEB87999xEG9Y21WKVDCjG7yegnJzFBKnzttmQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "theoplayer": "^5 || ^6 || ^7 || ^8 || ^9 || ^10"
+        "theoplayer": "^5 || ^6 || ^7 || ^8 || ^9 || ^10 || ^11"
       }
     },
     "node_modules/@types/babel__core": {
@@ -10512,22 +10512,22 @@
       }
     },
     "node_modules/react-native-theoplayer": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/react-native-theoplayer/-/react-native-theoplayer-10.1.0.tgz",
-      "integrity": "sha512-Q25UM05nWgG/ASqNsOd+dGjLEzsHFu2Uu4It6rtgFwXocXRyIgqNEx54bDPDGdmWU6zoI3szEASEkVaDwiw6uw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-theoplayer/-/react-native-theoplayer-11.0.0.tgz",
+      "integrity": "sha512-A8VkVJPUD4VrWAsS4HHI7+IcZBOireDl+1n0k7/sh1UKVDxX5KWXqA/acawYWpCn83BhsjmxPJRMYEYwJvgbNQ==",
       "dev": true,
-      "license": "SEE LICENSE AT https://www.theoplayer.com/terms",
+      "license": "BSD-3-Clause-Clear",
       "dependencies": {
-        "@theoplayer/cmcd-connector-web": "^1.4.0",
+        "@theoplayer/cmcd-connector-web": "^1.5.0",
         "buffer": "^6.0.3"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "peerDependencies": {
         "react": "*",
         "react-native": "*",
-        "theoplayer": "^9.12.0 || ^10"
+        "theoplayer": "^11"
       },
       "peerDependenciesMeta": {
         "theoplayer": {
@@ -11713,9 +11713,9 @@
       "license": "MIT"
     },
     "node_modules/theoplayer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-10.2.0.tgz",
-      "integrity": "sha512-Cu56Yt44AII65DMs0dMYuFLhY8KJFovoiK7AVoABLSTo7gttEtMDLZNrhGYct48rOvJpAUO0t4q1V6KASc2UZw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-11.0.0.tgz",
+      "integrity": "sha512-pxjpNtd++m87H5ndEPlNbKpHhXCNbFDgnXB0g6RfTv/v7zSpSLwiB0F0vIJe5asaqEJ6pKH7kvpTgnaEN2TElw==",
       "dev": true,
       "license": "SEE LICENSE AT https://www.theoplayer.com/terms",
       "peer": true

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-native-builder-bob": "^0.39.1",
     "react-native-google-cast": "^4.8.3",
     "react-native-svg": "^15.8.0",
-    "react-native-theoplayer": "^10",
+    "react-native-theoplayer": "^11",
     "typedoc": "^0.25.13",
     "typedoc-plugin-external-resolver": "^1.0.3",
     "typedoc-plugin-mdn-links": "^3.3.4",


### PR DESCRIPTION
Bump `react-native-theoplayer` to version 11.0.0, but *only* in the `devDependencies`.