### PR TITLE
Scrubbing video timeline on iOS Safari

### DIFF
--- a/.changeset/tricky-teeth-rest.md
+++ b/.changeset/tricky-teeth-rest.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/react-native-ui': minor
+---
+
+Fixed an issue where the playhead on the `<SeekBar>` would occasionally snap back after scrubbing on iOS Safari.

--- a/.changeset/tricky-teeth-rest.md
+++ b/.changeset/tricky-teeth-rest.md
@@ -1,5 +1,5 @@
 ---
-'@theoplayer/react-native-ui': minor
+'@theoplayer/react-native-ui': patch
 ---
 
 Fixed an issue where the playhead on the `<SeekBar>` would occasionally snap back after scrubbing on iOS Safari.

--- a/src/ui/components/seekbar/SeekBar.tsx
+++ b/src/ui/components/seekbar/SeekBar.tsx
@@ -6,6 +6,7 @@ import { useChaptersTrack, useDebounce, useDuration, useSeekable } from '../../h
 import { SingleThumbnailView } from './thumbnail/SingleThumbnailView';
 import { useSlider } from './useSlider';
 import { TestIDs } from '../../utils/TestIDs';
+import { SeekBarTouchHandler } from './SeekBarTouchHandler';
 import { PlayerEventType, SeekedEvent } from 'react-native-theoplayer';
 import { fuzzyEquals } from '../../utils/NumberUtils';
 
@@ -164,27 +165,29 @@ export const SeekBar = (props: SeekBarProps) => {
       onLayout={(event: LayoutChangeEvent) => {
         setWidth(event.nativeEvent.layout.width);
       }}>
-      <Slider
-        disabled={disabled}
-        minimumValue={normalizedTime(seekableRange.start)}
-        maximumValue={normalizedTime(seekableRange.end)}
-        containerStyle={props.sliderContainerStyle ?? { marginHorizontal: 8 }}
-        minimumTrackStyle={props.sliderMinimumTrackStyle ?? {}}
-        maximumTrackStyle={props.sliderMaximumTrackStyle ?? {}}
-        step={1000}
-        renderAboveThumbComponent={renderAboveThumbComponent}
-        onSlidingStart={onSlidingStart}
-        onValueChange={onSlidingValueChange}
-        onSlidingComplete={onSlidingComplete}
-        value={sliderTime}
-        minimumTrackTintColor={theme.colors.seekBarMinimum}
-        maximumTrackTintColor={theme.colors.seekBarMaximum}
-        thumbTintColor={theme.colors.seekBarDot}
-        thumbStyle={StyleSheet.flatten(props.thumbStyle)}
-        thumbTouchSize={props.thumbTouchSize}
-        renderTrackMarkComponent={chapterMarkerTimes.length ? props.chapterMarkers : undefined}
-        trackMarks={chapterMarkerTimes}
-      />
+      <SeekBarTouchHandler>
+        <Slider
+          disabled={disabled}
+          minimumValue={normalizedTime(seekableRange.start)}
+          maximumValue={normalizedTime(seekableRange.end)}
+          containerStyle={props.sliderContainerStyle ?? { marginHorizontal: 8 }}
+          minimumTrackStyle={props.sliderMinimumTrackStyle ?? {}}
+          maximumTrackStyle={props.sliderMaximumTrackStyle ?? {}}
+          step={1000}
+          renderAboveThumbComponent={renderAboveThumbComponent}
+          onSlidingStart={onSlidingStart}
+          onValueChange={onSlidingValueChange}
+          onSlidingComplete={onSlidingComplete}
+          value={sliderTime}
+          minimumTrackTintColor={theme.colors.seekBarMinimum}
+          maximumTrackTintColor={theme.colors.seekBarMaximum}
+          thumbTintColor={theme.colors.seekBarDot}
+          thumbStyle={StyleSheet.flatten(props.thumbStyle)}
+          thumbTouchSize={props.thumbTouchSize}
+          renderTrackMarkComponent={chapterMarkerTimes.length ? props.chapterMarkers : undefined}
+          trackMarks={chapterMarkerTimes}
+        />
+      </SeekBarTouchHandler>
     </View>
   );
 };

--- a/src/ui/components/seekbar/SeekBarTouchHandler.tsx
+++ b/src/ui/components/seekbar/SeekBarTouchHandler.tsx
@@ -1,0 +1,8 @@
+import React, { PropsWithChildren } from 'react';
+
+/**
+ * Native passthrough component - no touch event handling needed on native platforms.
+ */
+export const SeekBarTouchHandler = ({ children }: PropsWithChildren) => {
+  return <>{children}</>;
+};

--- a/src/ui/components/seekbar/SeekBarTouchHandler.web.tsx
+++ b/src/ui/components/seekbar/SeekBarTouchHandler.web.tsx
@@ -1,0 +1,19 @@
+import React, { PropsWithChildren, useCallback } from 'react';
+import { GestureResponderEvent, View } from 'react-native';
+
+/**
+ * Web-specific wrapper that calls preventDefault on touchstart and touchend events.
+ * This prevents iOS Safari from firing synthetic mouse events after touch events,
+ * which would cause the slider to snap back to its original position during scrubbing.
+ */
+export const SeekBarTouchHandler = ({ children }: PropsWithChildren) => {
+  const onTouchEvent = useCallback((e: GestureResponderEvent) => {
+    e.preventDefault();
+  }, []);
+
+  return (
+    <View onTouchStart={onTouchEvent} onTouchEnd={onTouchEvent}>
+      {children}
+    </View>
+  );
+};


### PR DESCRIPTION
While scrubbing in a quick touch-and-release way on iOS Safari, the playhead would sometimes snap back to a different value, instead of ending where we let go of the seek bar.

This is fixed by preventing the default `touchstart` and `touchend` actions on web, similar to how we handle this in the native SDK.