### PR TITLE
fix(ui): build live indicator glyph at runtime to avoid release-mode mojibake

### DIFF
--- a/.changeset/live-indicator-web-release.md
+++ b/.changeset/live-indicator-web-release.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/react-native-ui': patch
+---
+
+Fixed an issue on Web where the live indicator was rendered as a corrupted character (mojibake) in release builds.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,36 @@
+# Code Review Guidelines
+
+**Be VERY concise.**
+
+## Checklist
+
+### Changeset
+
+Every PR that changes runtime behavior **must** include a changeset entry in `.changeset/`.
+
+If one is missing, suggest adding a file `.changeset/<short-slug>.md`:
+
+```md
+---
+'@theoplayer/react-native-ui': patch|minor|major
+---
+
+<One-line description of the change. End with a full stop.>
+```
+
+Use `patch` for bug fixes, `minor` for new features, `major` for breaking changes.
+
+### API surface
+
+- Public API changes must be exported from the package entry (`src/index.tsx`).
+- Avoid breaking existing public types without a major version bump.
+
+### Docs
+
+- Public API needs TSDoc comments — `npm run docs` runs TypeDoc with `--treatWarningsAsErrors`, so undocumented or broken references fail.
+
+### Code quality
+
+- No `eslint-disable` or `@ts-ignore` without justification.
+- Prettier is enforced via pre-commit hook (`printWidth: 150`); don't manually override.
+- Avoid embedding raw non-ASCII characters in source; they can break in minified/release web bundles.

--- a/src/ui/components/button/GoToLiveButton.tsx
+++ b/src/ui/components/button/GoToLiveButton.tsx
@@ -58,7 +58,7 @@ export function GoToLiveButton(props: LiveButtonProps) {
       onPress={goToLive}
       touchable={true}>
       <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-        <Text style={[context.style.text, { color: liveIndicatorColor, marginRight: 6 }]}>●</Text>
+        <Text style={[context.style.text, { color: liveIndicatorColor, marginRight: 6 }]}>{String.fromCodePoint(9679)}</Text>
         <Text style={[context.style.text, { color: context.style.colors.text }, textStyle]}>{context.locale.liveLabel}</Text>
       </View>
     </ActionButton>


### PR DESCRIPTION
## Summary
The live indicator `●` (U+25CF) rendered as mojibake `â—` in web **release** builds. It was a raw non-ASCII glyph in the output bundle, and correct display depended on the served bundle being decoded as UTF-8 — not guaranteed across static hosts/CDNs (dev works only because webpack-dev-server sends `charset=utf-8`). A source escape (`\u25CF`) doesn't help: terser un-escapes it back to the raw glyph during minification.

Fix: keep the `●` out of the source entirely and build it at runtime, so the emitted bundle stays ASCII (terser won't constant-fold `String.fromCodePoint` unless `unsafe` is enabled).

```diff
- <Text ...>●</Text>
+ <Text ...>{String.fromCodePoint(9679)}</Text>
```

Verified: the `web-release` bundle no longer contains the raw `●` byte sequence (`E2 97 8F`) and the runtime `fromCodePoint(9679)` call survives minification; lint/prettier pass.


Link to Devin session: https://dolby.devinenterprise.com/sessions/53b41d6c6beb4b88984929b5cc172d73
Requested by: @tvanlaerhoven
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/react-native-theoplayer-ui/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->