### PR TITLE
Fix skip buttons missing for MP4 sources with empty seekable range

### DIFF
--- a/.changeset/rich-seals-grin.md
+++ b/.changeset/rich-seals-grin.md
@@ -2,4 +2,4 @@
 "@theoplayer/react-native-ui": patch
 ---
 
-Fixed skip buttons not appearing for MP4 sources whose `seekable` range stays empty even when a duration is known. `SkipButton` now remains visible when the media has a finite duration (mirroring `SeekBar`'s fallback), and `useSeekable` additionally refreshes on `loadedmetadata`, `loadeddata` and `durationchange` instead of only on `progress` (OPTI-3159).
+Fixed skip buttons not appearing for MP4 sources whose `seekable` range stays empty even when a duration is known. `SkipButton` now remains visible when the media has a finite duration (mirroring `SeekBar`'s fallback).

--- a/.changeset/rich-seals-grin.md
+++ b/.changeset/rich-seals-grin.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/react-native-ui": patch
+---
+
+Fixed skip buttons not appearing for MP4 sources whose `seekable` range stays empty even when a duration is known. `SkipButton` now remains visible when the media has a finite duration (mirroring `SeekBar`'s fallback), and `useSeekable` additionally refreshes on `loadedmetadata`, `loadeddata` and `durationchange` instead of only on `progress` (OPTI-3159).

--- a/src/ui/components/button/SkipButton.tsx
+++ b/src/ui/components/button/SkipButton.tsx
@@ -7,6 +7,7 @@ import { Animated, Easing, StyleSheet, Text, View } from 'react-native';
 import { BackwardSvg } from './svg/BackwardSvg';
 import type { ButtonBaseProps } from './ButtonBaseProps';
 import { useSeekable } from '../../hooks/useSeekable';
+import { useDuration } from '../../hooks/useDuration';
 
 export interface SkipButtonProps extends ButtonBaseProps {
   /**
@@ -38,6 +39,7 @@ export function SkipButton(props: SkipButtonProps) {
   const spinValue = useRef<Animated.Value>(new Animated.Value(0)).current;
   const { player, ui, style: uiStyle } = useContext(PlayerContext);
   const seekable = useSeekable();
+  const duration = useDuration();
 
   const spin = spinValue.interpolate({
     inputRange: [0, 1],
@@ -67,7 +69,11 @@ export function SkipButton(props: SkipButtonProps) {
   const forwardSvg: ReactNode = icon?.forward ?? <ForwardSvg />;
   const backwardSvg: ReactNode = icon?.backward ?? <BackwardSvg />;
 
-  if (seekable.length === 0) {
+  // Mirror the SeekBar seekable-range fallback: treat the media as seekable when there is a
+  // seekable range, or when only a finite duration is known (e.g. MP4, where seekable stays
+  // empty). Kept inline rather than extracted into a shared hook to keep this change minimal.
+  const isSeekable = seekable.length > 0 || (isFinite(duration) && duration > 0);
+  if (!isSeekable) {
     return <></>;
   }
 


### PR DESCRIPTION
# Summary
Skip (forward/backward) buttons were not rendered for progressive MP4 sources, even though the content is seekable and the seek bar works. This was most visible with preload: 'none'/'metadata'.

# Root cause
`SkipButton` gated its visibility on the player's seekable range:


```tsx
if (seekable.length === 0) {
  return <></>;
}
```
For progressive MP4, `player.seekable` legitimately stays empty until data is buffered (unlike HLS/DASH, where the manifest populates it immediately), even after a finite duration is known. As a result the buttons never appeared, despite the media being seekable — the same situation SeekBar already handles via a duration fallback.

# Fix
Treat the media as seekable when there is a seekable range or when a finite, positive duration is known — mirroring `SeekBar`'s existing fallback:

```tsx
const isSeekable = seekable.length > 0 || (isFinite(duration) && duration > 0);
if (!isSeekable) {
  return <></>;
}
```

Live/unbounded streams report duration === Infinity, so the isFinite guard keeps them correctly excluded.
Kept inline (rather than extracted into a shared hook) to keep the change minimal; centralizing the shared "effective seekability" logic with SeekBar is a possible follow-up.

# Testing

Reproduced with the ticket's MP4 source (poster + sideloaded subtitles, preload: 'none', no autoplay) in the example app on iOS.

## App.tsx

```tsx
player.autoplay = false;
player.preload = 'auto';

player.source = {
  sources: [
    {
      src: 'https://cdn.theoplayer.com/video/elephants-dream.mp4',
      type: 'video/mp4',
    },
  ],
  poster: 'https://fastly.picsum.photos/id/93/200/300.jpg?hmac=_9xpriBgFwY9RX_KtR53oeWtaQaNroWVr-4a9aJ0g_4',
  metadata: {
    title: 'Elephants Dream',
    subtitle: 'MP4 - preload none',
    album: 'React-Native THEOplayer demos',
    mediaUri: 'https://theoplayer.com',
    artist: 'THEOplayer',
  },
  textTracks: [
    {
      kind: TextTrackKind.subtitles,
      src: 'https://cdn.theoplayer.com/video/sintel/chapters.vtt',
      format: 'webvtt',
      srclang: 'en',
      label: 'Test',
      default: true,
    },
  ],
};
```

## Before

Skip buttons absent.

https://github.com/user-attachments/assets/c2dbb97b-ff6d-4844-83a8-5d0050a2977b


## After

Skip buttons visible and functional once duration is known.


https://github.com/user-attachments/assets/e4cb5db9-a91c-4942-8ad4-40de274146f2
